### PR TITLE
Add force fullscreen plugin

### DIFF
--- a/metadata/force-fullscreen.xml
+++ b/metadata/force-fullscreen.xml
@@ -8,6 +8,10 @@
 	</option>
 	<option name="preserve_aspect" type="bool">
 		<_short>Preserve Aspect Ratio</_short>
+		<default>true</default>
+	</option>
+	<option name="constraint_pointer" type="bool">
+		<_short>Constrain Mouse Pointer to Output</_short>
 		<default>false</default>
 	</option>
 	<option name="transparent_behind_views" type="bool">

--- a/metadata/force-fullscreen.xml
+++ b/metadata/force-fullscreen.xml
@@ -10,5 +10,9 @@
 		<_short>Preserve Aspect Ratio</_short>
 		<default>false</default>
 	</option>
+	<option name="transparent_behind_views" type="bool">
+		<_short>Transparent Behind Views</_short>
+		<default>true</default>
+	</option>
 	</plugin>
 </wayfire>

--- a/metadata/force-fullscreen.xml
+++ b/metadata/force-fullscreen.xml
@@ -10,13 +10,26 @@
 		<_short>Preserve Aspect Ratio</_short>
 		<default>true</default>
 	</option>
-	<option name="constraint_pointer" type="bool">
-		<_short>Constrain Mouse Pointer to Output</_short>
-		<default>false</default>
-	</option>
 	<option name="transparent_behind_views" type="bool">
 		<_short>Transparent Behind Views</_short>
 		<default>true</default>
+	</option>
+	<option name="constrain_pointer" type="bool">
+		<_short>Constrain Mouse Pointer</_short>
+		<default>false</default>
+	</option>
+	<option name="constraint_area" type="string">
+		<_short>Constraint Area</_short>
+		<_long>If constrain pointer is enabled, constrain to this area.</_long>
+		<default>view</default>
+		<desc>
+			<value>view</value>
+			<_name>View</_name>
+		</desc>
+		<desc>
+			<value>output</value>
+			<_name>Output</_name>
+		</desc>
 	</option>
 	</plugin>
 </wayfire>

--- a/metadata/force-fullscreen.xml
+++ b/metadata/force-fullscreen.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<wayfire>
+	<plugin name="force-fullscreen">
+	<_short>Fullscreen Window</_short>
+	<option name="key_toggle_fullscreen" type="key">
+		<_short>Key Toggle Fullscreen</_short>
+		<default>&lt;super&gt; &lt;alt&gt; KEY_F</default>
+	</option>
+	<option name="preserve_aspect" type="bool">
+		<_short>Preserve Aspect Ratio</_short>
+		<default>false</default>
+	</option>
+	</plugin>
+</wayfire>

--- a/metadata/meson.build
+++ b/metadata/meson.build
@@ -2,4 +2,5 @@ install_data('annotate.xml', install_dir: wayfire.get_variable(pkgconfig: 'metad
 install_data('autorotate-iio.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('background-view.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('bench.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
+install_data('force-fullscreen.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('join-views.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -24,7 +24,6 @@
  */
 
 #include <map>
-#include <unordered_set>
 #include <wayfire/core.hpp>
 #include <wayfire/plugin.hpp>
 #include <wayfire/output.hpp>

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -455,7 +455,6 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
             return;
         }
         wf::get_core().connect_signal("pointer_motion", &on_motion_event);
-        on_motion_event(nullptr);
         motion_connected = true;
     }
 

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -60,7 +60,6 @@ class fullscreen_subsurface : public wf::surface_interface_t, public wf::composi
 
     wf::point_t get_offset() override
     {
-        /* TODO: support below the surface as well, if wider than screen */
         return {-1, 0};
     }
 
@@ -301,13 +300,10 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         }
 
         wlr_box box;
-        box.width = std::floor(vg.width * scale_x);
-        box.height = std::floor(vg.height * scale_y);
-        box.x = std::floor((og.width - box.width) / 2.0);
-        box.y = std::floor((og.height - box.height) / 2.0);
-
-        scale_x += 1.0 / vg.width;
-        scale_y += 1.0 / vg.height;
+        box.width = std::floor((vg.width - 2) * scale_x);
+        box.height = std::floor((vg.height - 2) * scale_y);
+        box.x = std::ceil((og.width - box.width) / 2.0);
+        box.y = std::ceil((og.height - box.height) / 2.0);
 
         if (preserve_aspect)
         {

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -278,10 +278,13 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         auto og = output->get_relative_geometry();
         auto vg = view->get_wm_geometry();
 
-        double scale_x = (double) og.width / (vg.width - 1);
+        vg.width--;
+        vg.height--;
+
+        double scale_x = (double) og.width / vg.width;
         double scale_y = (double) og.height / vg.height;
-        double translation_x = (og.width - vg.width - 1) / 2.0;
-        double translation_y = (og.height - vg.height - 1) / 2.0;
+        double translation_x = (og.width - vg.width - 2) / 2.0;
+        double translation_y = (og.height - vg.height - 2) / 2.0;
 
         if (preserve_aspect)
         {
@@ -292,8 +295,8 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         wlr_box box;
         if (transparent_behind_views)
         {
-            box.width = (vg.width - 1) * scale_x;
-            box.height = (vg.height - 1) * scale_y;
+            box.width = vg.width * scale_x;
+            box.height = vg.height * scale_y;
             box.x = (og.width - box.width) / 2.0;
             box.y = (og.height - box.height) / 2.0;
         }

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -499,14 +499,18 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         {
             auto cursor = wf::get_core().get_cursor_position();
             auto og = output->get_layout_geometry();
-
-            if (og & wf::pointf_t{cursor.x, cursor.y})
+            for (auto& b : backgrounds)
             {
-                return;
+                auto view = output->get_active_view();
+                if (b.first == view &&
+                    !(og & wf::pointf_t{cursor.x, cursor.y}))
+                {
+                    wlr_box_closest_point(&og, cursor.x, cursor.y,
+                        &cursor.x, &cursor.y);
+                    wf::get_core().warp_cursor(cursor.x, cursor.y);
+                    return;
+                }
             }
-
-            wlr_box_closest_point(&og, cursor.x, cursor.y, &cursor.x, &cursor.y);
-            wf::get_core().warp_cursor(cursor.x, cursor.y);
         });
     };
 

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -299,15 +299,14 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
 
         if (preserve_aspect)
         {
-            scale_x = std::min(scale_x, scale_y);
-            scale_y = std::min(scale_x, scale_y);
+            scale_x = scale_y = std::min(scale_x, scale_y);
         }
 
         wlr_box box;
-        box.width = vg.width * (scale_x + 1.0 / og.width);
-        box.height = vg.height * (scale_y + 1.0 / og.height);
-        box.x = (og.width - box.width) / 2.0;
-        box.y = (og.height - box.height) / 2.0;
+        box.width = std::ceil(vg.width * scale_x);
+        box.height = std::ceil(vg.height * scale_y);
+        box.x = std::floor((og.width - box.width) / 2.0);
+        box.y = std::floor((og.height - box.height) / 2.0);
 
         backgrounds[view]->transformer->transformed_view_box = box;
         backgrounds[view]->transformer->scale_x = scale_x;

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -510,36 +510,35 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         cursor.y += ev->event->delta_y;
         for (auto& b : backgrounds)
         {
-            wlr_box box;
-            if (std::string(constraint_area) == "view")
-            {
-                box = b.second->transformer->transformed_view_box;
-                box.x += og.x;
-                box.y += og.y;
-            }
-            else if (std::string(constraint_area) == "output")
-            {
-                box = og;
-            }
-            else
-            {
-                box = og;
-            }
             auto view = output->get_active_view();
+            wlr_box box;
+
+            box = b.second->transformer->transformed_view_box;
+            box.x += og.x;
+            box.y += og.y;
+
+            if (std::string(constraint_area) == "output")
+            {
+                box = og;
+            }
+
             if (b.first == view &&
                 !(box & wf::pointf_t{cursor.x, cursor.y}))
             {
-                if (ev->event->unaccel_dx < box.x || ev->event->unaccel_dx > box.x + box.width)
+                if (ev->event->unaccel_dx < box.x ||
+                    ev->event->unaccel_dx > box.x + box.width)
                 {
                     ev->event->delta_x = 0;
                 }
-                if (ev->event->unaccel_dy < box.y || ev->event->unaccel_dy > box.y + box.height)
+                if (ev->event->unaccel_dy < box.y ||
+                    ev->event->unaccel_dy > box.y + box.height)
                 {
                     ev->event->delta_y = 0;
                 }
                 wlr_box_closest_point(&box, cursor.x, cursor.y,
                     &cursor.x, &cursor.y);
                 wf::get_core().warp_cursor(cursor.x, cursor.y);
+
                 return;
             }
         }

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -127,6 +127,7 @@ class fullscreen_transformer : public wf::view_2D
             return bbox;
         }
     }
+
     wlr_box get_relative_transformed_view_box(wlr_box& og)
     {
         auto ws = get_workspace(og);
@@ -420,7 +421,11 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
             view_fullscreened.disconnect();
             view_unmapped.disconnect();
         }
-        view->move(background->second->saved_geometry.x, background->second->saved_geometry.y);
+        auto og = output->get_relative_geometry();
+        auto ws = background->second->transformer->get_workspace(og);
+        view->move(
+            background->second->saved_geometry.x + ws.x * og.width,
+            background->second->saved_geometry.y + ws.y * og.height);
         if (view->get_transformer(background_name))
         {
             view->pop_transformer(background_name);

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -1,0 +1,391 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Scott Moreau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <map>
+#include <unordered_set>
+#include <wayfire/core.hpp>
+#include <wayfire/plugin.hpp>
+#include <wayfire/output.hpp>
+#include <wayfire/view-transform.hpp>
+#include <wayfire/workspace-manager.hpp>
+#include <wayfire/signal-definitions.hpp>
+
+class fullscreen_transformer : public wf::view_2D
+{
+    wf::option_wrapper_t<bool> preserve_aspect{"force-fullscreen/preserve_aspect"};
+
+  public:
+    bool fullscreen;
+    wayfire_view view;
+    wf::point_t workspace;
+    wlr_box output_geometry;
+    wf::geometry_t saved_geometry;
+
+    fullscreen_transformer(wayfire_view view) : wf::view_2D(view)
+    {
+        this->view = view;
+        fullscreen = false;
+    }
+
+    ~fullscreen_transformer() { }
+
+    void setup_transform(wlr_box og)
+    {
+        auto vg = view->get_wm_geometry();
+
+        output_geometry = og;
+        scale_x = (double) og.width / vg.width;
+        scale_y = (double) og.height / vg.height;
+        translation_x = (og.width - vg.width) / 2.0;
+        translation_y = (og.height - vg.height) / 2.0;
+    }
+
+    wf::point_t get_workspace(wlr_box og)
+    {
+        wf::point_t ws;
+        auto vg = view->get_output_geometry();
+        wf::pointf_t center{vg.x + vg.width / 2.0, vg.y + vg.height / 2.0};
+
+        ws.x = std::floor(center.x / og.width);
+        ws.y = std::floor(center.y / og.height);
+
+        return ws;
+    }
+
+    wlr_box get_workspace_geometry(wlr_box og)
+    {
+        wf::point_t ws = workspace = get_workspace(og);
+
+        og.x += ws.x * og.width;
+        og.y += ws.y * og.height;
+
+        return og;
+    }
+
+    wlr_box get_bounding_box(wf::geometry_t view, wlr_box region) override
+    {
+        return get_workspace_geometry(output_geometry);
+    }
+
+    void render_box(wf::texture_t src_tex, wlr_box src_box,
+        wlr_box scissor_box, const wf::framebuffer_t& target_fb) override
+    {
+        wf::pointf_t saved_scale;
+
+        OpenGL::render_begin(target_fb);
+        target_fb.logic_scissor(scissor_box);
+        OpenGL::clear({0, 0, 0, 1});
+        OpenGL::render_end();
+
+        if (preserve_aspect)
+        {
+            saved_scale = wf::pointf_t{scale_x, scale_y};
+            if (scale_x > scale_y)
+            {
+                scale_x = scale_y;
+            }
+            else if (scale_x < scale_y)
+            {
+                scale_y = scale_x;
+            }
+        }
+
+        wf::view_2D::render_box(src_tex, src_box, scissor_box, target_fb);
+
+        if (preserve_aspect)
+        {
+            scale_x = saved_scale.x;
+            scale_y = saved_scale.y;
+        }
+    }
+};
+
+class wayfire_force_fullscreen;
+
+std::map<wf::output_t*, wayfire_force_fullscreen*> wayfire_force_fullscreen_instances;
+
+class wayfire_force_fullscreen : public wf::plugin_interface_t
+{
+    std::string transformer_name;
+    std::unordered_multiset<fullscreen_transformer*> transformers;
+    wf::option_wrapper_t<bool> preserve_aspect{"force-fullscreen/preserve_aspect"};
+    wf::option_wrapper_t<wf::keybinding_t> key_toggle_fullscreen{"force-fullscreen/key_toggle_fullscreen"};
+
+  public:
+    void init() override
+    {
+        this->grab_interface->name = "force-fullscreen";
+        this->grab_interface->capabilities = wf::CAPABILITY_MANAGE_COMPOSITOR;
+        transformer_name = this->grab_interface->name;
+
+        output->add_key(key_toggle_fullscreen, &on_toggle_fullscreen);
+        preserve_aspect.set_callback(preserve_aspect_option_changed);
+        wayfire_force_fullscreen_instances[output] = this;
+    }
+
+    fullscreen_transformer *get_transformer(wf::point_t workspace)
+    {
+        for (auto t : transformers)
+        {
+            if (t->workspace == workspace)
+            {
+                return t;
+            }
+        }
+
+        return nullptr;
+    }
+
+    fullscreen_transformer *get_transformer(wayfire_view view)
+    {
+        for (auto t : transformers)
+        {
+            if (t->view == view)
+            {
+                return t;
+            }
+        }
+
+        return nullptr;
+    }
+
+    void setup_transform(fullscreen_transformer *transformer)
+    {
+        auto og = output->get_relative_geometry();
+
+        transformer->setup_transform(og);
+        transformer->view->damage();
+    }
+
+    wf::config::option_base_t::updated_callback_t preserve_aspect_option_changed = [=] ()
+    {
+        for (auto& t : transformers)
+        {
+            setup_transform(t);
+        }
+    };
+
+    bool toggle_fullscreen(wayfire_view view)
+    {
+        if (!output->activate_plugin(grab_interface))
+        {
+            return false;
+        }
+
+        auto transformer = get_transformer(view);
+        wlr_box saved_geometry;
+        bool fullscreen;
+
+        fullscreen = transformer ? false : true;
+
+        wlr_box vg = view->get_output_geometry();
+
+        if (fullscreen)
+        {
+            saved_geometry = vg;
+        }
+
+        view->set_fullscreen(fullscreen);
+
+        if (fullscreen)
+        {
+            vg = view->get_wm_geometry();
+            saved_geometry.width = vg.width;
+            saved_geometry.height = vg.height;
+        }
+        else
+        {
+            deactivate(view);
+            return true;
+        }
+
+        activate(view);
+
+        transformer = get_transformer(view);
+        transformer->fullscreen = true;
+        transformer->saved_geometry = saved_geometry;
+
+        return true;
+    }
+
+    wf::key_callback on_toggle_fullscreen = [=] (uint32_t key)
+    {
+        auto view = output->get_active_view();
+        auto ws = output->workspace->get_current_workspace();
+        auto transformer = get_transformer(ws);
+
+        if (!view)
+        {
+            return false;
+        }
+
+        if (transformer && transformer->fullscreen && view != transformer->view)
+        {
+            return false;
+        }
+
+        return toggle_fullscreen(view);
+    };
+
+    void activate(wayfire_view view)
+    {
+        view->move(0, 0);
+        fullscreen_transformer *transformer = new fullscreen_transformer(view);
+        view->add_transformer(std::unique_ptr<fullscreen_transformer>(transformer), transformer_name);
+        output->connect_signal("output-configuration-changed", &output_config_changed);
+        wf::get_core().connect_signal("view-move-to-output", &view_output_changed);
+        output->connect_signal("view-fullscreen-request", &view_fullscreened);
+        view->connect_signal("geometry-changed", &view_geometry_changed);
+        output->connect_signal("unmap-view", &view_unmapped);
+        output->deactivate_plugin(grab_interface);
+        transformers.insert(transformer);
+        setup_transform(transformer);
+    }
+
+    void deactivate(wayfire_view view)
+    {
+        output->deactivate_plugin(grab_interface);
+        auto transformer = get_transformer(view);
+
+        if (!transformer)
+        {
+            return;
+        }
+
+        view_geometry_changed.disconnect();
+        output_config_changed.disconnect();
+        view_output_changed.disconnect();
+        view_fullscreened.disconnect();
+        view_unmapped.disconnect();
+        view->move(transformer->saved_geometry.x, transformer->saved_geometry.y);
+        transformers.erase(transformer);
+        if (view->get_transformer(transformer_name))
+        {
+            view->pop_transformer(transformer_name);
+        }
+    }
+
+    wf::signal_connection_t output_config_changed{[this] (wf::signal_data_t *data)
+    {
+        wf::output_configuration_changed_signal *signal =
+            static_cast<wf::output_configuration_changed_signal*>(data);
+
+        if (!signal->changed_fields)
+        {
+            return;
+        }
+
+        if (signal->changed_fields & wf::OUTPUT_SOURCE_CHANGE)
+        {
+            return;
+        }
+
+        for (auto& t : transformers)
+        {
+            setup_transform(t);
+        }
+    }};
+
+    wf::signal_connection_t view_output_changed{[this] (wf::signal_data_t *data)
+    {
+        auto signal = static_cast<wf::view_move_to_output_signal*> (data);
+        auto view = signal->view;
+        auto transformer = get_transformer(view);
+
+        if (!transformer)
+        {
+            return;
+        }
+
+        if (transformer->fullscreen)
+        {
+            toggle_fullscreen(view);
+        }
+
+        auto instance = wayfire_force_fullscreen_instances[signal->new_output];
+        instance->toggle_fullscreen(view);
+    }};
+
+    wf::signal_connection_t view_unmapped{[this] (wf::signal_data_t *data)
+    {
+        auto view = get_signaled_view(data);
+        auto transformer = get_transformer(view);
+
+        if (!transformer)
+        {
+            return;
+        }
+
+        if (transformer->fullscreen)
+        {
+            toggle_fullscreen(view);
+        }
+    }};
+
+    wf::signal_connection_t view_fullscreened{[this] (wf::signal_data_t *data)
+    {
+        auto signal = static_cast<view_fullscreen_signal*> (data);
+        auto view = signal->view;
+        auto transformer = get_transformer(view);
+
+        if (!transformer)
+        {
+            return;
+        }
+
+        if (signal->state || signal->carried_out)
+        {
+            return;
+        }
+
+        if (transformer->fullscreen)
+        {
+            toggle_fullscreen(view);
+        }
+
+        signal->carried_out = true;
+    }};
+
+    wf::signal_connection_t view_geometry_changed{[this] (wf::signal_data_t *data)
+    {
+        auto view = get_signaled_view(data);
+        auto transformer = get_transformer(view);
+
+        if (!transformer)
+        {
+            return;
+        }
+
+        view->resize(transformer->saved_geometry.width, transformer->saved_geometry.height);
+        setup_transform(transformer);
+    }};
+
+    void fini() override
+    {
+        output->rem_binding(&on_toggle_fullscreen);
+        wayfire_force_fullscreen_instances.erase(output);
+    }
+};
+
+DECLARE_WAYFIRE_PLUGIN(wayfire_force_fullscreen);

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -394,8 +394,8 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         wf::get_core().connect_signal("view-move-to-output", &view_output_changed);
         output->connect_signal("view-fullscreen-request", &view_fullscreened);
         view->connect_signal("geometry-changed", &view_geometry_changed);
-            output->connect_signal("focus-view", &view_focused);
         output->connect_signal("unmap-view", &view_unmapped);
+        output->connect_signal("focus-view", &view_focused);
         output->deactivate_plugin(grab_interface);
         if (constraint_pointer)
         {

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -514,8 +514,10 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
             wlr_box box;
 
             box = b.second->transformer->transformed_view_box;
-            box.x += og.x;
-            box.y += og.y;
+            box.x += og.x + 1;
+            box.y += og.y + 1;
+            box.width -= 2;
+            box.height -= 2;
 
             if (std::string(constraint_area) == "output")
             {

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -33,8 +33,6 @@
 #include <wayfire/workspace-manager.hpp>
 #include <wayfire/signal-definitions.hpp>
 
-#include <glm/gtc/matrix_transform.hpp>
-
 
 class fullscreen_subsurface : public wf::surface_interface_t, public wf::compositor_surface_t
 {
@@ -118,11 +116,14 @@ class fullscreen_transformer : public wf::view_2D
         wf::point_t subsurface = {wm.x - 1, wm.y};
         auto og = output->get_relative_geometry();
         auto ws = get_workspace(og);
-        if (box & subsurface) {
+        if (box & subsurface)
+        {
             og.x += ws.x * og.width;
             og.y += ws.y * og.height;
             return og;
-        } else {
+        }
+        else
+        {
             bbox.x += ws.x * og.width;
             bbox.y += ws.y * og.height;
             return bbox;

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  *
+ * Copyright (c) 2020 Ilia Bozhinov
  * Copyright (c) 2020 Scott Moreau
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -32,28 +33,26 @@
 #include <wayfire/workspace-manager.hpp>
 #include <wayfire/signal-definitions.hpp>
 
+#include <glm/gtc/matrix_transform.hpp>
+
+
 class fullscreen_subsurface : public wf::surface_interface_t, public wf::compositor_surface_t
 {
   public:
     bool _mapped = true;
-    wf::geometry_t geometry;
-
     fullscreen_subsurface(wayfire_view view)
         : wf::surface_interface_t(), wf::compositor_surface_t() {}
 
-    ~fullscreen_subsurface()
+    ~fullscreen_subsurface() {}
+
+    void on_pointer_enter(int x, int y) override
     {
-        _mapped = false;
-        wf::emit_map_state_change(this);
+        wf::get_core().set_cursor("default");
     }
 
     bool accepts_input(int32_t sx, int32_t sy) override
     {
-        if (sx < geometry.x || sx > geometry.x + geometry.width ||
-            sy < geometry.y || sy > geometry.y + geometry.height)
-            return false;
-
-        return true;
+        return wlr_box{0, 0, 1, 1} & wf::point_t{sx, sy};
     }
 
     bool is_mapped() const override
@@ -63,34 +62,143 @@ class fullscreen_subsurface : public wf::surface_interface_t, public wf::composi
 
     wf::point_t get_offset() override
     {
-        return {geometry.x, geometry.y};
+        /* TODO: support below the surface as well, if wider than screen */
+        return {-1, 0};
     }
 
     wf::dimensions_t get_size() const override
     {
-        return {geometry.width, geometry.height};
+        return {1, 1};
     }
 
     void simple_render(const wf::framebuffer_t& fb, int x, int y,
         const wf::region_t& damage) override
+    { /* fully transparent */ }
+};
+
+class fullscreen_transformer : public wf::view_2D
+{
+  public:
+    wayfire_view view;
+    wlr_box transformed_view_box;
+
+    fullscreen_transformer(wayfire_view view) : wf::view_2D(view)
     {
-        OpenGL::render_begin(fb);
-        for (const auto& box : damage)
+        this->view = view;
+    }
+
+    ~fullscreen_transformer() {}
+
+    wf::point_t get_workspace(wlr_box og)
+    {
+        wf::point_t ws;
+        auto vg = view->get_output_geometry();
+        wf::pointf_t center{vg.x + vg.width / 2.0, vg.y + vg.height / 2.0};
+
+        ws.x = std::floor(center.x / og.width);
+        ws.y = std::floor(center.y / og.height);
+
+        return ws;
+    }
+
+    /* TODO: transform_point */
+    wf::geometry_t get_bounding_box(
+        wf::geometry_t geometry, wf::geometry_t box) override
+    {
+        auto output = view->get_output();
+        auto bbox = wf::view_2D::get_bounding_box(geometry, box);
+
+        if (!output)
         {
-            fb.logic_scissor(wlr_box_from_pixman_box(box));
-            OpenGL::clear({0, 0, 0, 1});
+            return bbox;
         }
-        OpenGL::render_end();
+
+        wf::geometry_t wm = view->get_wm_geometry();
+        wf::point_t subsurface = {wm.x - 1, wm.y};
+        auto og = output->get_relative_geometry();
+        auto ws = get_workspace(og);
+        if (box & subsurface) {
+            og.x += ws.x * og.width;
+            og.y += ws.y * og.height;
+            return og;
+        } else {
+            bbox.x += ws.x * og.width;
+            bbox.y += ws.y * og.height;
+            return bbox;
+        }
+    }
+    wlr_box get_relative_transformed_view_box(wlr_box& og)
+    {
+        auto ws = get_workspace(og);
+        auto bbox = transformed_view_box;
+        bbox.x += ws.x * og.width;
+        bbox.y += ws.y * og.height;
+        og.x += ws.x * og.width;
+        og.y += ws.y * og.height;
+        return bbox;
+    }
+
+    wf::pointf_t untransform_point(
+        wf::geometry_t geometry, wf::pointf_t point) override
+    {
+        auto output = view->get_output();
+        auto default_point = wf::view_2D::untransform_point(geometry, point);
+
+        if (!output)
+        {
+            return default_point;
+        }
+
+        auto og = output->get_relative_geometry();
+        auto bbox = get_relative_transformed_view_box(og);
+
+        if (!(bbox & point))
+        {
+            auto region = ((wf::region_t{og} ^ wf::region_t{bbox}) &
+                wf::region_t{{(int) point.x, (int) point.y, 1, 1}});
+            if (!region.empty())
+            {
+                auto wm = view->get_wm_geometry();
+                return wf::pointf_t{wm.x - 1.0, wm.y * 1.0};
+            }
+        }
+        return default_point;
+    }
+
+    void render_box(wf::texture_t src_tex, wlr_box src_box,
+        wlr_box scissor_box, const wf::framebuffer_t& target_fb) override
+    {
+        auto output = view->get_output();
+
+        if (!output)
+        {
+            return;
+        }
+
+        auto og = output->get_relative_geometry();
+        auto bbox = get_relative_transformed_view_box(og);
+        wf::region_t vr{bbox};
+        wf::region_t scissor_region{scissor_box};
+        scissor_region ^= vr;
+        for (auto& b : scissor_region)
+        {
+            OpenGL::render_begin(target_fb);
+            target_fb.logic_scissor(wlr_box_from_pixman_box(b));
+            OpenGL::clear({0, 0, 0, 1});
+            OpenGL::render_end();
+        }
+
+        wf::view_2D::render_box(src_tex, src_box, scissor_box, target_fb);
     }
 };
 
 class fullscreen_background
 {
   public:
-    wf::view_2D *transformer;
     wf::geometry_t saved_geometry;
-    fullscreen_subsurface *subsurface_a = nullptr;
-    fullscreen_subsurface *subsurface_b = nullptr;
+    wf::geometry_t undecorated_geometry;
+    fullscreen_transformer *transformer;
+    fullscreen_subsurface *black_border = nullptr;
 
     fullscreen_background(wayfire_view view) {}
 
@@ -103,24 +211,28 @@ std::map<wf::output_t*, wayfire_force_fullscreen*> wayfire_force_fullscreen_inst
 
 class wayfire_force_fullscreen : public wf::plugin_interface_t
 {
+    double saved_wrot_angle;
     std::string background_name;
+    wf::view_2D *wrot_transformer;
     std::map<wayfire_view, std::unique_ptr<fullscreen_background>> backgrounds;
     wf::option_wrapper_t<bool> preserve_aspect{"force-fullscreen/preserve_aspect"};
+    wf::option_wrapper_t<bool> transparent_behind_views{"force-fullscreen/transparent_behind_views"};
     wf::option_wrapper_t<wf::keybinding_t> key_toggle_fullscreen{"force-fullscreen/key_toggle_fullscreen"};
 
   public:
     void init() override
     {
         this->grab_interface->name = "force-fullscreen";
-        this->grab_interface->capabilities = wf::CAPABILITY_MANAGE_COMPOSITOR;
+        this->grab_interface->capabilities = 0;
         background_name = this->grab_interface->name;
 
         output->add_key(key_toggle_fullscreen, &on_toggle_fullscreen);
-        preserve_aspect.set_callback(preserve_aspect_option_changed);
+        preserve_aspect.set_callback(option_changed);
+        transparent_behind_views.set_callback(option_changed);
         wayfire_force_fullscreen_instances[output] = this;
     }
 
-    void create_subsurfaces(wayfire_view view)
+    void ensure_subsurface(wayfire_view view)
     {
         auto pair = backgrounds.find(view);
 
@@ -131,23 +243,16 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
 
         auto& background = pair->second;
 
-        if (!background->subsurface_a)
+        if (!background->black_border)
         {
-            std::unique_ptr<fullscreen_subsurface> subsurface_a = std::make_unique<fullscreen_subsurface>(view);
-            nonstd::observer_ptr<fullscreen_subsurface> ptr{subsurface_a};
-            view->add_subsurface(std::move(subsurface_a), true);
-            background->subsurface_a = ptr.get();
-        }
-        if (!background->subsurface_b)
-        {
-            std::unique_ptr<fullscreen_subsurface> subsurface_b = std::make_unique<fullscreen_subsurface>(view);
-            nonstd::observer_ptr<fullscreen_subsurface> ptr{subsurface_b};
-            view->add_subsurface(std::move(subsurface_b), true);
-            background->subsurface_b = ptr.get();
+            std::unique_ptr<fullscreen_subsurface> subsurface = std::make_unique<fullscreen_subsurface>(view);
+            nonstd::observer_ptr<fullscreen_subsurface> ptr{subsurface};
+            view->add_subsurface(std::move(subsurface), true);
+            background->black_border = ptr.get();
         }
     }
 
-    void destroy_subsurfaces(wayfire_view view)
+    void destroy_subsurface(wayfire_view view)
     {
         auto pair = backgrounds.find(view);
 
@@ -158,15 +263,12 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
 
         auto& background = pair->second;
 
-        if (background->subsurface_a)
+        if (background->black_border)
         {
-            view->remove_subsurface(background->subsurface_a);
-            background->subsurface_a = nullptr;
-        }
-        if (background->subsurface_b)
-        {
-            view->remove_subsurface(background->subsurface_b);
-            background->subsurface_b = nullptr;
+            wf::emit_map_state_change(background->black_border);
+            background->black_border->_mapped = false;
+            view->remove_subsurface(background->black_border);
+            background->black_border = nullptr;
         }
     }
 
@@ -174,62 +276,59 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
     {
         auto og = output->get_relative_geometry();
         auto vg = view->get_wm_geometry();
-        wf::geometry_t subsurface_a;
-        wf::geometry_t subsurface_b;
 
-        double scale_x = (double) og.width / vg.width;
+        double scale_x = (double) og.width / (vg.width - 1);
         double scale_y = (double) og.height / vg.height;
-        double translation_x = (og.width - vg.width) / 2.0;
-        double translation_y = (og.height - vg.height) / 2.0;
+        double translation_x = (og.width - vg.width - 1) / 2.0;
+        double translation_y = (og.height - vg.height - 1) / 2.0;
 
         if (preserve_aspect)
         {
-            if (scale_x > scale_y)
-            {
-                scale_x = scale_y;
-                subsurface_a.width = ((og.width * (1.0 / scale_x)) - vg.width) / 2.0 + 1;
-                subsurface_a.height = vg.height;
-                subsurface_a.x = -subsurface_a.width;
-                subsurface_a.y = 0;
-                subsurface_b = subsurface_a;
-                subsurface_b.x = vg.width;
-                subsurface_b.y = 0;
-            }
-            else if (scale_x < scale_y)
-            {
-                scale_y = scale_x;
-                subsurface_a.width = vg.width;
-                subsurface_a.height = ((og.height * (1.0 / scale_y)) - vg.height) / 2.0 + 1;
-                subsurface_a.x = 0;
-                subsurface_a.y = -subsurface_a.height;
-                subsurface_b = subsurface_a;
-                subsurface_b.x = 0;
-                subsurface_b.y = vg.height;
-            }
-
-            create_subsurfaces(view);
-            backgrounds[view]->subsurface_a->geometry = subsurface_a;
-            backgrounds[view]->subsurface_b->geometry = subsurface_b;
+            scale_x = std::min(scale_x, scale_y);
+            scale_y = std::min(scale_x, scale_y);
         }
 
+        wlr_box box;
+        if (transparent_behind_views)
+        {
+            box.width = (vg.width - 1) * scale_x;
+            box.height = (vg.height - 1) * scale_y;
+            box.x = (og.width - box.width) / 2.0;
+            box.y = (og.height - box.height) / 2.0;
+        }
+        else
+        {
+            box = {0, 0, 0, 0};
+        }
+
+        backgrounds[view]->transformer->transformed_view_box = box;
         backgrounds[view]->transformer->scale_x = scale_x;
         backgrounds[view]->transformer->scale_y = scale_y;
         backgrounds[view]->transformer->translation_x = translation_x;
         backgrounds[view]->transformer->translation_y = translation_y;
+
+        if (preserve_aspect)
+        {
+            ensure_subsurface(view);
+        }
+        else
+        {
+            destroy_subsurface(view);
+        }
 
         view->damage();
     }
 
     void update_backgrounds()
     {
-	for (auto& b : backgrounds)
-	{
-            destroy_subsurfaces(b.first);
+        for (auto& b : backgrounds)
+        {
+            destroy_subsurface(b.first);
             setup_transform(b.first);
-	}
+        }
     }
 
-    wf::config::option_base_t::updated_callback_t preserve_aspect_option_changed = [=] ()
+    wf::config::option_base_t::updated_callback_t option_changed = [=] ()
     {
         update_backgrounds();
     };
@@ -248,6 +347,8 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
 
         view->set_fullscreen(fullscreen);
 
+        wlr_box undecorated_geometry = view->get_wm_geometry();
+
         if (!fullscreen)
         {
             deactivate(view);
@@ -259,8 +360,11 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         background = backgrounds.find(view);
         if (background != backgrounds.end())
         {
+            background->second->undecorated_geometry = undecorated_geometry;
             background->second->saved_geometry = saved_geometry;
         }
+
+        setup_transform(view);
 
         return true;
     }
@@ -268,14 +372,8 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
     wf::key_callback on_toggle_fullscreen = [=] (uint32_t key)
     {
         auto view = output->get_active_view();
-        auto background = backgrounds.find(view);
 
         if (!view)
-        {
-            return false;
-        }
-
-        if (background != backgrounds.end() && view != background->first)
         {
             return false;
         }
@@ -287,15 +385,21 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
     {
         view->move(0, 0);
         backgrounds[view] = std::make_unique<fullscreen_background>(view);
-        backgrounds[view]->transformer = new wf::view_2D(view);
-        view->add_transformer(std::unique_ptr<wf::view_2D>(backgrounds[view]->transformer), background_name);
+        backgrounds[view]->transformer = new fullscreen_transformer(view);
+        view->add_transformer(std::unique_ptr<fullscreen_transformer>(backgrounds[view]->transformer), background_name);
         output->connect_signal("output-configuration-changed", &output_config_changed);
         wf::get_core().connect_signal("view-move-to-output", &view_output_changed);
         output->connect_signal("view-fullscreen-request", &view_fullscreened);
         view->connect_signal("geometry-changed", &view_geometry_changed);
         output->connect_signal("unmap-view", &view_unmapped);
         output->deactivate_plugin(grab_interface);
-        setup_transform(view);
+
+        if (view->get_transformer("wrot"))
+        {
+            wrot_transformer = dynamic_cast<wf::view_2D*> (view->get_transformer("wrot").get());
+            saved_wrot_angle = wrot_transformer->angle;
+            wrot_transformer->angle = 0.0;
+        }
     }
 
     void deactivate(wayfire_view view)
@@ -321,7 +425,12 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         {
             view->pop_transformer(background_name);
         }
-        destroy_subsurfaces(view);
+
+        if (view->get_transformer("wrot"))
+        {
+            wrot_transformer->angle = saved_wrot_angle;
+        }
+        destroy_subsurface(view);
         backgrounds.erase(view);
     }
 
@@ -404,7 +513,9 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
             return;
         }
 
-        view->resize(background->second->saved_geometry.width, background->second->saved_geometry.height);
+        view->resize(
+            background->second->undecorated_geometry.width,
+            background->second->undecorated_geometry.height);
         setup_transform(view);
     }};
 

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -483,6 +483,11 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
         auto ev = static_cast<
             wf::input_event_signal<wlr_event_pointer_motion>*>(data);
 
+        if (wf::get_core().get_active_output() != output)
+        {
+            return;
+        }
+
         if (!output->can_activate_plugin(grab_interface))
         {
             return;

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -374,7 +374,7 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
     {
         auto view = output->get_active_view();
 
-        if (!view)
+        if (!view || view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT)
         {
             return false;
         }

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -514,10 +514,8 @@ class wayfire_force_fullscreen : public wf::plugin_interface_t
             wlr_box box;
 
             box = b.second->transformer->transformed_view_box;
-            box.x += og.x + 1;
-            box.y += og.y + 1;
-            box.width -= 2;
-            box.height -= 2;
+            box.x += og.x;
+            box.y += og.y;
 
             if (std::string(constraint_area) == "output")
             {

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,6 +14,10 @@ benchmark = shared_module('bench', 'bench.cpp',
     dependencies: [wayfire, wlroots, wfconfig, cairo],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
+force_fullscreen = shared_module('force-fullscreen', 'force-fullscreen.cpp',
+    dependencies: [wayfire, wlroots, wfconfig],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
 joinviews = shared_module('join-views', 'join-views.cpp',
     dependencies: [wayfire, wlroots, wfconfig],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))


### PR DESCRIPTION
This plugin facilitates a way to force fullscreen on applications that do not support it, or otherwise have problems with fullscreen. The fullscreen state is emulated by stretching the surface to the fullscreen dimensions or by rendering the surface centered with black borders if preserve aspect option is set. This is useful for programs that do not fullscreen properly or at all. For example, if you have an xwayland game that does not support resize or fullscreen, you can still use this plugin to run it fullscreen. Examples include dosbox and scummvm. This is primarily useful for xwayland views but can be used on any native non-desktop views that can be focused, as well.