### PR TITLE
[UPDATE] Follow focus

### DIFF
--- a/metadata/follow-focus.xml
+++ b/metadata/follow-focus.xml
@@ -25,5 +25,10 @@
 			<default>10</default>
 			<min>0</min>
 		</option>
+		<option name="raise_on_top" type="bool">
+			<_short>Raise the focused view to the top</_short>
+			<_long>If disabled the focused view will only get keyboard focus, but will not be raised to the top.</_long>
+			<default>true</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/follow-focus.xml
+++ b/metadata/follow-focus.xml
@@ -3,5 +3,15 @@
 	<plugin name="follow-focus">
 		<_short>Focus follows mouse</_short>
 		<category>Desktop</category>
+		<option name="change_view" type="bool">
+			<_short>View focus follows mouse</_short>
+			<_long>When the mouse pointer is moved, the view focus changes to the view under the pointer.</_long>
+			<default>true</default>
+		</option>
+		<option name="change_output" type="bool">
+			<_short>Output focus follows mouse</_short>
+			<_long>When the mouse pointer is moved, the output focus changes to the output that the pointer is currently on.</_long>
+			<default>true</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/follow-focus.xml
+++ b/metadata/follow-focus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <wayfire>
-  <plugin name="follow-focus">
-    <_short>Focus follows mouse</_short>
-    <category>Desktop</category>
-  </plugin>
+	<plugin name="follow-focus">
+		<_short>Focus follows mouse</_short>
+		<category>Desktop</category>
+	</plugin>
 </wayfire>

--- a/metadata/follow-focus.xml
+++ b/metadata/follow-focus.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<wayfire>
+  <plugin name="follow-focus">
+    <_short>Focus follows mouse</_short>
+    <category>Desktop</category>
+  </plugin>
+</wayfire>

--- a/metadata/follow-focus.xml
+++ b/metadata/follow-focus.xml
@@ -19,5 +19,11 @@
 			<default>50</default>
 			<min>5</min>
 		</option>
+		<option name="threshold" type="int">
+			<_short>Minimum cursor movement</_short>
+			<_long>The distance (x+y) the cursor should be moved at least before the plugin gets activated</_long>
+			<default>10</default>
+			<min>0</min>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/follow-focus.xml
+++ b/metadata/follow-focus.xml
@@ -13,5 +13,11 @@
 			<_long>When the mouse pointer is moved, the output focus changes to the output that the pointer is currently on.</_long>
 			<default>true</default>
 		</option>
+		<option name="focus_delay" type="int">
+			<_short>Delay (in ms) before focus change will be triggered</_short>
+			<_long>The delay in ms before the plugin will trigger a focus change after the movement finished.</_long>
+			<default>50</default>
+			<min>5</min>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/meson.build
+++ b/metadata/meson.build
@@ -4,6 +4,7 @@ install_data('background-view.xml', install_dir: wayfire.get_variable(pkgconfig:
 install_data('bench.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('force-fullscreen.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('join-views.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
+install_data('follow-focus.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('keycolor.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('mag.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('showrepaint.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))

--- a/metadata/meson.build
+++ b/metadata/meson.build
@@ -2,6 +2,7 @@ install_data('annotate.xml', install_dir: wayfire.get_variable(pkgconfig: 'metad
 install_data('autorotate-iio.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('background-view.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('bench.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
+install_data('follow-focus.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('force-fullscreen.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('join-views.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('follow-focus.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))

--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -42,11 +42,16 @@ class wayfire_follow_focus : public wf::plugin_interface_t
     wf::option_wrapper_t<bool> should_change_output{"follow-focus/change_output"};
     wf::option_wrapper_t<int> focus_delay{"follow-focus/focus_delay"};
     wf::option_wrapper_t<int> threshold{"follow-focus/threshold"};
+    wf::option_wrapper_t<bool> raise_on_top{"follow-focus/raise_on_top"};
 
     void change_view()
     {
         auto view = wf::get_core().get_cursor_focus_view();
-        wf::get_core().set_active_view(view);
+
+        if (raise_on_top)
+            wf::get_core().focus_view(view);
+        else
+            wf::get_core().set_active_view(view);
     }
 
     void change_output()

--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -32,10 +32,11 @@
 class wayfire_follow_focus : public wf::plugin_interface_t
 {
    private:
-    wf::wl_idle_call change_focus;
+    wf::wl_timer change_focus;
 
     wf::option_wrapper_t<bool> should_change_view{"follow-focus/change_view"};
     wf::option_wrapper_t<bool> should_change_output{"follow-focus/change_output"};
+    wf::option_wrapper_t<int> focus_delay{"follow-focus/focus_delay"};
 
     void change_view()
     {
@@ -55,7 +56,10 @@ class wayfire_follow_focus : public wf::plugin_interface_t
     }
 
     wf::signal_callback_t pointer_motion = [=] (wf::signal_data_t * /*data*/) {
-        change_focus.run_once([=] () {
+        change_focus.disconnect();
+
+        /* Restart the timeout */
+        change_focus.set_timeout(focus_delay, [=] () {
             if (should_change_view)
                 change_view();
 

--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Till Smejkal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <wayfire/plugin.hpp>
+#include <wayfire/core.hpp>
+#include <wayfire/view.hpp>
+#include <wayfire/util.hpp>
+
+
+class wayfire_follow_focus : public wf::plugin_interface_t
+{
+   private:
+    wf::wl_idle_call change_active_view;
+
+    wf::signal_callback_t pointer_motion = [=] (wf::signal_data_t * /*data*/) {
+        change_active_view.run_once( [] () {
+            auto view = wf::get_core().get_cursor_focus_view();
+            wf::get_core().set_active_view(view);
+        });
+    };
+
+   public:
+    void init() override
+    {
+        grab_interface->name = "follow-focus";
+        grab_interface->capabilities = 0;
+
+        wf::get_core().connect_signal("pointer_motion", &pointer_motion);
+    }
+
+    void fini() override
+    {
+        wf::get_core().disconnect_signal("pointer_motion", &pointer_motion);
+        change_active_view.disconnect();
+    }
+};
+
+
+DECLARE_WAYFIRE_PLUGIN(wayfire_follow_focus);

--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -31,7 +31,7 @@
 
 class wayfire_follow_focus : public wf::plugin_interface_t
 {
-   private:
+  private:
     wf::wl_timer change_focus;
     wayfire_view last_view;
 
@@ -47,54 +47,83 @@ class wayfire_follow_focus : public wf::plugin_interface_t
     void change_view(wayfire_view view)
     {
         if (raise_on_top)
+        {
             wf::get_core().focus_view(view);
-        else
+        } else
+        {
             wf::get_core().set_active_view(view);
+        }
     }
 
     void change_output()
     {
         auto coords = wf::get_core().get_cursor_position();
-        for (auto output : wf::get_core().output_layout->get_outputs()) {
-            if (output->get_layout_geometry() & coords) {
+        for (auto output : wf::get_core().output_layout->get_outputs())
+        {
+            if (output->get_layout_geometry() & coords)
+            {
                 wf::get_core().focus_output(output);
+
                 return;
             }
         }
     }
 
-    void view_changed_cb() {
+    void view_changed_cb()
+    {
         wayfire_view view = wf::get_core().get_cursor_focus_view();
-        if (view != last_view) { return; }
-        if (threshold) {
+        if (view != last_view)
+        {
+            return;
+        }
+
+        if (threshold)
+        {
             wf::pointf_t coords = wf::get_core().get_cursor_position();
-            // XXX(xaiki): this is slightly wrong because we check a square and not a circle,
-            //              but it should be good enough, and save casting twice to wf::point_t
-            if (abs(last_coords.x - coords.x) + abs(last_coords.y - coords.y) < threshold) {
-                change_focus.set_timeout(focus_delay, [=]() { view_changed_cb(); });
+            // XXX(xaiki): this is slightly wrong because we check a square and not a
+            // circle, but it should be good enough, and save casting twice to
+            // wf::point_t
+
+            if (abs(last_coords.x - coords.x) + abs(last_coords.y - coords.y) <
+                threshold)
+            {
+                change_focus.set_timeout(focus_delay, [=] () { view_changed_cb(); });
+
                 return;
             }
         }
+
         if (should_change_view)
+        {
             change_view(view);
+        }
 
         if (should_change_output)
+        {
             change_output();
+        }
     }
 
-    wf::signal_callback_t pointer_motion = [=] (wf::signal_data_t * /*data*/) {
+    wf::signal_callback_t pointer_motion = [=] (wf::signal_data_t* /*data*/)
+    {
         wayfire_view view = wf::get_core().get_cursor_focus_view();
-        if (view == nullptr || view == last_view) { return; };
-        if (threshold) {
+        if ((view == nullptr) || (view == last_view))
+        {
+            return;
+        }
+
+        if (threshold)
+        {
             last_coords = wf::get_core().get_cursor_position();
         }
+
         last_view = view;
 
         /* Restart the timeout */
-        change_focus.set_timeout(focus_delay, [=]() { view_changed_cb(); });
+        change_focus.set_timeout(focus_delay, [=] () { view_changed_cb(); });
     };
 
-   public:
+  public:
     void init() override
     {
         grab_interface->name = "follow-focus";

--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -36,7 +36,7 @@ class wayfire_follow_focus : public wf::plugin_interface_t
     wayfire_view last_view     = nullptr;
     bool waiting_for_threshold = false;
 
-    wf::pointf_t last_coords;
+    wf::point_t last_coords;
     double distance;
 
     wf::option_wrapper_t<bool> should_change_view{"follow-focus/change_view"};
@@ -80,17 +80,15 @@ class wayfire_follow_focus : public wf::plugin_interface_t
 
         if (threshold)
         {
-            wf::pointf_t coords = wf::get_core().get_cursor_position();
-            // XXX(xaiki): this is slightly wrong because we check a square and not a
-            // circle, but it should be good enough, and save casting twice to
-            // wf::point_t
-
-            if (abs(last_coords.x - coords.x) + abs(last_coords.y - coords.y) <
-                threshold)
+            auto cpf = wf::get_core().get_cursor_position();
+            wf::point_t coords{static_cast<int>(cpf.x), static_cast<int>(cpf.y)};
+            if (abs(coords - last_coords) < threshold)
             {
                 waiting_for_threshold = true;
+
                 return;
             }
+
             waiting_for_threshold = false;
         }
 
@@ -123,7 +121,10 @@ class wayfire_follow_focus : public wf::plugin_interface_t
         {
             if (threshold)
             {
-                last_coords = wf::get_core().get_cursor_position();
+                auto cpf = wf::get_core().get_cursor_position();
+                wf::point_t coords{static_cast<int>(cpf.x), static_cast<int>(cpf.y)};
+
+                last_coords = coords;
             }
 
             // only update the view if we're not waiting_for_threshold

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,15 +14,15 @@ benchmark = shared_module('bench', 'bench.cpp',
     dependencies: [wayfire, wlroots, wfconfig, cairo],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
+follow_focus = shared_module('follow-focus', 'follow-focus.cpp',
+    dependencies: [wayfire, wlroots, wfconfig],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
 force_fullscreen = shared_module('force-fullscreen', 'force-fullscreen.cpp',
     dependencies: [wayfire, wlroots, wfconfig],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 joinviews = shared_module('join-views', 'join-views.cpp',
-    dependencies: [wayfire, wlroots, wfconfig],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-
-follow_focus = shared_module('follow-focus', 'follow-focus.cpp',
     dependencies: [wayfire, wlroots, wfconfig],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,10 @@ joinviews = shared_module('join-views', 'join-views.cpp',
     dependencies: [wayfire, wlroots, wfconfig],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
+follow_focus = shared_module('follow-focus', 'follow-focus.cpp',
+    dependencies: [wayfire, wlroots, wfconfig],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
 keycolor = shared_module('keycolor', 'keycolor.cpp',
     dependencies: [wayfire, wlroots, wfconfig],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))


### PR DESCRIPTION
this adds a patch on https://github.com/WayfireWM/wayfire-plugins-extra/pull/17 
it fixes the background will make window loose focus bug, but not the 'alt-tab' one, for that we'd need to intercept that particular focus change and move the mouse, or maybe the alt-tab plugin should do it ?