### PR TITLE
adapt timers to upstream wayfire changes

### DIFF
--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -105,6 +105,7 @@ class wayfire_follow_focus : public wf::plugin_interface_t
         change_output_focus.set_timeout(focus_delay, [=] ()
         {
             change_output();
+            return false; // disconnect
         });
     }
 
@@ -155,6 +156,7 @@ class wayfire_follow_focus : public wf::plugin_interface_t
         change_view_focus.set_timeout(focus_delay, [=] ()
         {
             change_view();
+            return false; // disconnect
         });
     }
 

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -255,7 +255,7 @@ class wayfire_water_screen : public wf::plugin_interface_t
     wf::wl_timer::callback_t timeout = [=] ()
     {
         animation.animate(animation, 0);
-        timer.disconnect();
+        return false; // disconnect
     };
 
     wf::post_hook_t render = [=] (const wf::framebuffer_base_t& source,

--- a/src/workspace-names.cpp
+++ b/src/workspace-names.cpp
@@ -395,8 +395,9 @@ class wayfire_workspace_names_screen : public wf::plugin_interface_t
     {
         output->render->damage_whole();
         alpha_fade.animate(1.0, 0.0);
-        timer.disconnect();
         timed_out = true;
+
+        return false; // disconnect
     };
 
     wf::signal_connection_t workspace_stream_post{[this] (wf::signal_data_t *data)


### PR DESCRIPTION
Sending this commit here, I plan to make a change in core so that timers can be used to repeat actions in a certain time.
This means that the callback signature needs to be changed to bool, so that the timer knows whether to continue or not.

The Wayfire PR has not been merged yet, so this is not to be merged right now.
