### PR TITLE
add glib-main-loop plugin

### DIFF
--- a/src/glib-main-loop.cpp
+++ b/src/glib-main-loop.cpp
@@ -100,6 +100,7 @@ class glib_main_loop_t
                 plugin_prefixes.push_back(entry);
             }
         }
+
         plugin_prefixes.push_back(PLUGIN_PATH);
 
         std::string plugin_name = "glib-main-loop";

--- a/src/glib-main-loop.cpp
+++ b/src/glib-main-loop.cpp
@@ -1,0 +1,128 @@
+#include <wayfire/singleton-plugin.hpp>
+#include <wayfire/plugin.hpp>
+#include <wayfire/core.hpp>
+#include <glibmm/main.h>
+#include <giomm/init.h>
+#include <glibmm/init.h>
+#include <wayfire/util/log.hpp>
+#include <wayfire/config.h>
+#include <filesystem>
+#include <dlfcn.h>
+
+#include <glib-2.0/glib-unix.h>
+
+static gboolean on_wayland_fd_event(gint fd, GIOCondition condition,
+    gpointer user_data);
+
+namespace wf
+{
+class glib_main_loop_t
+{
+    Glib::RefPtr<Glib::MainLoop> g_loop;
+
+  public:
+    glib_main_loop_t()
+    {
+        // IMPORTANT!
+        // Ensure that the .so file for this plugin is never closed, by opening it
+        // with dlopen() once more.
+        auto path = find_plugin_in_path();
+        if (path.empty())
+        {
+            LOGE("Failed to find libglib-main-loop.so! ",
+                "Add it to the WAYFIRE_PLUGIN_PATH.");
+            return;
+        }
+
+        auto handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+        if (handle == NULL)
+        {
+            LOGE("Failed to open ", path, ", glib-main-loop cannot work!");
+            return;
+        }
+
+        LOGI("creating main loop");
+
+        Glib::init();
+        Gio::init();
+
+        g_loop = Glib::MainLoop::create();
+        wf::get_core().connect_signal("startup-finished", &glib_loop_run);
+        wf::get_core().connect_signal("shutdown", &glib_loop_quit);
+    }
+
+    void handle_wayland_fd_in(GIOCondition flag)
+    {
+        if (flag != G_IO_IN)
+        {
+            LOGE("A problem in the Wayland event loop has been detected!");
+            g_loop->quit();
+            return;
+        }
+
+        wl_display_flush_clients(wf::get_core().display);
+        wl_event_loop_dispatch(wf::get_core().ev_loop, 0);
+        wl_display_flush_clients(wf::get_core().display);
+    }
+
+    wf::signal_connection_t glib_loop_run = [=] (auto)
+    {
+        auto fd = wl_event_loop_get_fd(wf::get_core().ev_loop);
+        g_unix_fd_add(fd, G_IO_IN, on_wayland_fd_event, this);
+        g_unix_fd_add(fd, G_IO_ERR, on_wayland_fd_event, this);
+        g_unix_fd_add(fd, G_IO_HUP, on_wayland_fd_event, this);
+
+        g_loop->run();
+    };
+
+    wf::signal_connection_t glib_loop_quit = [=] (auto)
+    {
+        auto display = wf::get_core().display;
+        wl_display_destroy_clients(display);
+        wl_display_destroy(display);
+        std::exit(0);
+    };
+
+    /**
+     * Find the path to this plugin, by searching in Wayfire's search path.
+     *
+     * Code adapted from plugin-loader.cpp
+     */
+    std::string find_plugin_in_path()
+    {
+        std::vector<std::string> plugin_prefixes;
+        if (char *plugin_path = getenv("WAYFIRE_PLUGIN_PATH"))
+        {
+            std::stringstream ss(plugin_path);
+            std::string entry;
+            while (std::getline(ss, entry, ':'))
+            {
+                plugin_prefixes.push_back(entry);
+            }
+        }
+        plugin_prefixes.push_back(PLUGIN_PATH);
+
+        std::string plugin_name = "glib-main-loop";
+        for (std::filesystem::path plugin_prefix : plugin_prefixes)
+        {
+            auto plugin_path = plugin_prefix / ("lib" + plugin_name + ".so");
+            if (std::filesystem::exists(plugin_path))
+            {
+                return plugin_path;
+            }
+        }
+
+        return "";
+    }
+};
+}
+
+static gboolean on_wayland_fd_event(gint, GIOCondition condition,
+    gpointer user_data)
+{
+    auto loop = (wf::glib_main_loop_t*)user_data;
+    loop->handle_wayland_fd_in(condition);
+    return true;
+}
+
+DECLARE_WAYFIRE_PLUGIN((wf::singleton_plugin_t<wf::glib_main_loop_t, true>));

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,10 @@ force_fullscreen = shared_module('force-fullscreen', 'force-fullscreen.cpp',
     dependencies: [wayfire, wlroots, wfconfig],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
+glib_main_loop = shared_module('glib-main-loop', 'glib-main-loop.cpp',
+    dependencies: [wayfire, wlroots, wfconfig, giomm],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
 joinviews = shared_module('join-views', 'join-views.cpp',
     dependencies: [wayfire, wlroots, wfconfig],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))


### PR DESCRIPTION
This is a plugin which overrides Wayfire's main loop, and utilizes
Glib's one instead. It can be used in plugins like wf-gsettings,
    autorotate-iio, etc, which don't need to roll their own event loop
    or use threads at all.

Sample changes for autorotate so that it doesn't have its own loop:

<details>

```diff
diff --git a/src/autorotate-iio.cpp b/src/autorotate-iio.cpp
index bb0d5f6..c8e7076 100644
--- a/src/autorotate-iio.cpp
+++ b/src/autorotate-iio.cpp
@@ -9,10 +9,6 @@
 #include <giomm/dbusconnection.h>
 #include <giomm/dbuswatchname.h>
 #include <giomm/dbusproxy.h>
-#include <giomm/init.h>
-
-#include <glibmm/main.h>
-#include <glibmm/init.h>

 #include <map>

@@ -75,7 +71,7 @@ class WayfireAutorotateIIO : public wf::plugin_interface_t
     wf::option_wrapper_t<bool>
     config_rotation_locked{"autorotate-iio/lock_rotation"};

-    guint watch_id;
+    guint watch_id = -1;
     wf::activator_callback on_rotate_left = [=] (auto)
     {
         return on_rotate_binding(WL_OUTPUT_TRANSFORM_90);
@@ -148,12 +144,6 @@ class WayfireAutorotateIIO : public wf::plugin_interface_t
         return true;
     }

-    wf::effect_hook_t on_frame = [=] ()
-    {
-        Glib::MainContext::get_default()->iteration(false);
-    };
-    Glib::RefPtr<Glib::MainLoop> loop;
-
   public:
     void init() override
     {
@@ -176,12 +166,6 @@ class WayfireAutorotateIIO : public wf::plugin_interface_t
             return;
         }

-        Glib::init();
-        Gio::init();
-
-        loop = Glib::MainLoop::create(true);
-        output->render->add_effect(&on_frame, wf::OUTPUT_EFFECT_PRE);
-
         watch_id = DBus::watch_name(DBus::BUS_TYPE_SYSTEM, "net.hadess.SensorProxy",
             sigc::mem_fun(this, &WayfireAutorotateIIO::on_iio_appeared),
             sigc::mem_fun(this, &WayfireAutorotateIIO::on_iio_disappeared));
@@ -257,13 +241,10 @@ class WayfireAutorotateIIO : public wf::plugin_interface_t
         wf::get_core().disconnect_signal("input-device-added",
             &on_input_devices_changed);

-        /* If loop is NULL, autorotate was disabled for the current output */
-        if (loop)
+        if (watch_id != (guint)-1)
         {
             iio_proxy.reset();
             DBus::unwatch_name(watch_id);
-            loop->quit();
-            output->render->rem_effect(&on_frame);
         }
     }
 };

```
</details>

I am currently not pushing these changes because autorotate-iio works
quite well, even without glib-main-loop, and I prefer to not have that
overhead to the main loop (even if the overhead is small).


Note: I am not sure if this is the correct place for such a plugin. I'm leaving it to your discretion @soreau.
