### PR TITLE
Update the path of windecor submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/damianatorrpm/wayfire-plugin_dbus_interface
 [submodule "subprojects/windecor"]
 	path = subprojects/windecor
-	url = https://gitlab.com/marcusbritanicus/windecor
+	url = https://gitlab.com/wayfireplugins/windecor


### PR DESCRIPTION
I have moved the submodule windecor from marcusbritanicus/windecor to wayfireplugins/windecor. This PR updates the submodule path.

@soreau Since I did a git pull --recurse-submodules the submodule paths are also updated.