### PR TITLE
background-view: Set sticky bit so the view appears on all workspaces again

### DIFF
--- a/src/background-view.cpp
+++ b/src/background-view.cpp
@@ -124,6 +124,9 @@ class wayfire_background_view : public wf::plugin_interface_t
         o->workspace->add_view(view, wf::LAYER_BACKGROUND);
 
         /* Make it show on all workspaces */
+        view->sticky = true;
+
+        /* Set role */
         view->role = wf::VIEW_ROLE_DESKTOP_ENVIRONMENT;
 
         /* Remember to close it later */


### PR DESCRIPTION
Since sticky concept introduction, setting role to desktop no longer causes the
surface to display on all workspaces. Setting the view sticky is required and
setting the role becomes a formality.