### PR TITLE
Added hinge detection plugin

### DIFF
--- a/metadata/hinge.xml
+++ b/metadata/hinge.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0"?>
 <wayfire>
-  <plugin name="hinge">
-    <_short>Hinge</_short>
-    <category>Utility</category>
-    <option name="filename" type="string">
-      <_short>File Name</_short>
-      <_long>The name of the sensor device.</_long>
-      <default>/sys/bus/iio/devices/iio:device1/in_angl0_raw</default>
-	  </option>
-    <option name="poll_freq" type="int">
+	<plugin name="hinge">
+		<_short>Hinge</_short>
+		<category>Utility</category>
+		<option name="filename" type="string">
+			<_short>File Name</_short>
+			<_long>The name of the sensor device.</_long>
+			<default>/sys/bus/iio/devices/iio:device1/in_angl0_raw</default>
+		</option>
+		<option name="poll_freq" type="int">
 			<_short>Poll Frequency</_short>
 			<_long>The delay between sensor readings in ms.</_long>
 			<default>200</default>
 			<min>1</min>
 		</option>
-    <option name="flip_degree" type="int">
-      <_short>Flip Degree</_short>
-      <_long>Inputs are disabled when the sensed degree is greater than the set Flip Degree.</_long>
-      <default>180</default>
-      <min>0</min>
-      <max>360</max>
-	  </option>
-  </plugin>
+		<option name="flip_degree" type="int">
+			<_short>Flip Degree</_short>
+			<_long>Inputs are disabled when the sensed degree is greater than the set Flip Degree.</_long>
+			<default>180</default>
+			<min>0</min>
+			<max>360</max>
+		</option>
+	</plugin>
 </wayfire>

--- a/metadata/hinge.xml
+++ b/metadata/hinge.xml
@@ -2,6 +2,7 @@
 <wayfire>
 	<plugin name="hinge">
 		<_short>Hinge</_short>
+		<_long>Given a filename, this plugin reads an int32 from it. This value should be in degrees, so from 0 to 360. Depending on the value, the keyboard and pointer inputs get disabled.</_long>
 		<category>Utility</category>
 		<option name="filename" type="string">
 			<_short>File Name</_short>

--- a/metadata/hinge.xml
+++ b/metadata/hinge.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<wayfire>
+  <plugin name="hinge">
+    <_short>Hinge</_short>
+    <category>Utility</category>
+    <option name="filename" type="string">
+      <_short>File Name</_short>
+      <_long>The name of the sensor device.</_long>
+      <default>/sys/bus/iio/devices/iio:device1/in_angl0_raw</default>
+	  </option>
+    <option name="poll_freq" type="int">
+			<_short>Poll Frequency</_short>
+			<_long>The delay between sensor readings in ms.</_long>
+			<default>200</default>
+			<min>1</min>
+		</option>
+    <option name="flip_degree" type="int">
+      <_short>Flip Degree</_short>
+      <_long>Inputs are disabled when the sensed degree is greater than the set Flip Degree.</_long>
+      <default>180</default>
+      <min>0</min>
+      <max>360</max>
+	  </option>
+  </plugin>
+</wayfire>

--- a/metadata/meson.build
+++ b/metadata/meson.build
@@ -13,3 +13,4 @@ install_data('view-shot.xml', install_dir: wayfire.get_variable(pkgconfig: 'meta
 install_data('water.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('window-zoom.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
 install_data('workspace-names.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
+install_data('hinge.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -2,10 +2,9 @@
 #include "wayfire/signal-definitions.hpp"
 #include "wayfire/input-device.hpp"
 #include <wayfire/util/log.hpp>
-#include <iostream>
 #include <fstream>
-#include <sstream>
 #include <vector>
+#include <string>
 
 class wayfire_hinge : public wf::plugin_interface_t
 {
@@ -25,7 +24,7 @@ class wayfire_hinge : public wf::plugin_interface_t
 
     bool read_device() 
     {   
-        char buf[1024];
+        char buf[4];
         device_file.seekg(0);
         device_file.readsome(buf, 4);
 
@@ -34,10 +33,8 @@ class wayfire_hinge : public wf::plugin_interface_t
             return false;
         }
         
-        int angle;
-        sscanf(buf, "%i", &angle);
-
-        if((angle < 0) | (angle > 360)) {
+        int angle = std::stoi(buf);
+        if(angle < 0 || angle > 360) {
             LOGE("Read invalid data from hinge sensor: ", angle);
             enable_inputs(); // So we don't get stuck with disabled inputs
             return true;

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -55,9 +55,8 @@ class wayfire_hinge : public wf::plugin_interface_t
 
     void disable_inputs() {
         input_enabled = false;
-        for (size_t i = 0; i < get_inputs().size(); i++)
+        for (auto inp: get_inputs())
         {
-            auto inp = get_inputs()[i];
             auto inp_type = inp->get_wlr_handle()->type;
             if(
             inp_type == wlr_input_device_type::WLR_INPUT_DEVICE_KEYBOARD || 
@@ -70,9 +69,8 @@ class wayfire_hinge : public wf::plugin_interface_t
 
     void enable_inputs() {
         input_enabled = true;
-        for (size_t i = 0; i < get_inputs().size(); i++)
+        for (auto inp: get_inputs())
         {
-            auto inp = get_inputs()[i];
             inp->set_enabled();
         }
     }

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -14,6 +14,7 @@ class wayfire_hinge : public wf::plugin_interface_t
     wf::option_wrapper_t<int> flip_degree{"hinge/flip_degree"};
     
     std::ifstream device_file;
+    wf::wl_timer* timer;
 
     bool input_enabled = true;
 
@@ -81,13 +82,11 @@ class wayfire_hinge : public wf::plugin_interface_t
         {
             device_file.open(file_name, std::ifstream::in);
 
-            auto timer = new wf::wl_timer();
+            timer = new wf::wl_timer();
             timer->set_timeout(poll_freq, [this] ()
             {
                 return read_device();
             });
-
-            
         }
 
         void fini() override

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -14,9 +14,13 @@ class wayfire_hinge : public wf::plugin_interface_t
     wf::option_wrapper_t<int> flip_degree{"hinge/flip_degree"};
     
     std::ifstream device_file;
-    std::vector<nonstd::observer_ptr<wf::input_device_t>> inputs;
 
     bool input_enabled = true;
+
+    std::vector<nonstd::observer_ptr<wf::input_device_t>> get_inputs() {
+        wf::compositor_core_t* core = &wf::get_core();
+        return core->get_input_devices();
+    }
 
     bool read_device() 
     {   
@@ -47,11 +51,13 @@ class wayfire_hinge : public wf::plugin_interface_t
         return true;
     }
 
+
+
     void disable_inputs() {
         input_enabled = false;
-        for (size_t i = 0; i < inputs.size(); i++)
+        for (size_t i = 0; i < get_inputs().size(); i++)
         {
-            auto inp = inputs[i];
+            auto inp = get_inputs()[i];
             auto inp_type = inp->get_wlr_handle()->type;
             if(
             inp_type == wlr_input_device_type::WLR_INPUT_DEVICE_KEYBOARD || 
@@ -64,9 +70,9 @@ class wayfire_hinge : public wf::plugin_interface_t
 
     void enable_inputs() {
         input_enabled = true;
-        for (size_t i = 0; i < inputs.size(); i++)
+        for (size_t i = 0; i < get_inputs().size(); i++)
         {
-            auto inp = inputs[i];
+            auto inp = get_inputs()[i];
             inp->set_enabled();
         }
     }
@@ -83,8 +89,7 @@ class wayfire_hinge : public wf::plugin_interface_t
                 return read_device();
             });
 
-            wf::compositor_core_t* core = &wf::get_core();
-            inputs = core->get_input_devices();
+            
         }
 
         void fini() override

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -10,7 +10,7 @@
 
 class wayfire_hinge : public wf::plugin_interface_t
 {
-    enum thread_message {
+    enum thread_message: char {
         ENABLE_INPUT,
         DISABLE_INPUT,
         THREAD_EXIT
@@ -82,7 +82,7 @@ class wayfire_hinge : public wf::plugin_interface_t
     }
 
     static void send_message(thread_message message, int pipe) {
-        write(pipe, (char*)&message, 1);
+        write(pipe, &message, 1);
     }
 
     static int on_pipe_update(int fd, uint32_t mask, void *data) {

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -10,64 +10,73 @@
 
 class wayfire_hinge : public wf::plugin_interface_t
 {
-    enum thread_message: char {
+    enum thread_message : char
+    {
         ENABLE_INPUT,
         DISABLE_INPUT,
-        THREAD_EXIT
+        THREAD_EXIT,
     };
 
     wf::option_wrapper_t<std::string> file_name{"hinge/filename"};
     wf::option_wrapper_t<int> poll_freq{"hinge/poll_freq"};
     wf::option_wrapper_t<int> flip_degree{"hinge/flip_degree"};
-    
+
     int pipefd[2];
     std::thread thread;
-    wl_event_source* pipe_reader;
+    wl_event_source *pipe_reader;
     bool exiting = false;
 
-    std::vector<nonstd::observer_ptr<wf::input_device_t>> get_inputs() {
-        wf::compositor_core_t* core = &wf::get_core();
-        return core->get_input_devices();
+    std::vector<nonstd::observer_ptr<wf::input_device_t>> get_inputs()
+    {
+        return wf::get_core().get_input_devices();
     }
 
-    void disable_inputs() {
-        for (auto inp: get_inputs())
+    void disable_inputs()
+    {
+        for (auto inp : get_inputs())
         {
             auto inp_type = inp->get_wlr_handle()->type;
-            if(
-            inp_type == wlr_input_device_type::WLR_INPUT_DEVICE_KEYBOARD || 
-            inp_type == wlr_input_device_type::WLR_INPUT_DEVICE_POINTER
-            ) {
+            if (
+                (inp_type == wlr_input_device_type::WLR_INPUT_DEVICE_KEYBOARD) ||
+                (inp_type == wlr_input_device_type::WLR_INPUT_DEVICE_POINTER))
+            {
                 inp->set_enabled(false);
             }
         }
     }
 
-    void enable_inputs() {
-        for (auto inp: get_inputs())
+    void enable_inputs()
+    {
+        for (auto inp : get_inputs())
         {
             inp->set_enabled();
         }
     }
 
-    static void setup_thread(std::string fn, int poll_freq, int flip_degree, bool* exiting, int write_fd) {
+    static void setup_thread(std::string fn, int poll_freq, int flip_degree,
+        bool *exiting, int write_fd)
+    {
         std::ifstream device_file(fn, std::ifstream::in);
         bool input_enabled = true;
 
-        while(!*exiting) {
+        while (!*exiting)
+        {
             char buf[4];
             device_file.seekg(0);
             device_file.readsome(buf, 4);
 
-            if(device_file.fail()) {
-                LOGE("Failed reading from hinge sensor device: ", device_file.rdstate());
+            if (device_file.fail())
+            {
+                LOGE("Failed reading from hinge sensor device: ",
+                    device_file.rdstate());
                 send_message(thread_message::THREAD_EXIT, write_fd);
                 device_file.close();
                 break;
             }
-            
+
             int angle = std::stoi(buf);
-            if(angle < 0 || angle > 360) {
+            if ((angle < 0) || (angle > 360))
+            {
                 LOGE("Read invalid data from hinge sensor: ", angle);
                 send_message(thread_message::THREAD_EXIT, write_fd);
                 device_file.close();
@@ -75,61 +84,82 @@ class wayfire_hinge : public wf::plugin_interface_t
             }
 
             bool new_state = angle < flip_degree;
-            if(new_state != input_enabled) {
-                if(new_state) send_message(thread_message::ENABLE_INPUT, write_fd);
-                else send_message(thread_message::DISABLE_INPUT, write_fd);
+            if (new_state != input_enabled)
+            {
+                if (new_state)
+                {
+                    send_message(thread_message::ENABLE_INPUT, write_fd);
+                } else
+                {
+                    send_message(thread_message::DISABLE_INPUT, write_fd);
+                }
+
                 input_enabled = new_state;
             }
+
             usleep(poll_freq * 1000); // microseconds*1000=ms
         }
+
         close(write_fd);
         device_file.close();
     }
 
-    static void send_message(thread_message message, int write_fd) {
+    static void send_message(thread_message message, int write_fd)
+    {
         write(write_fd, &message, 1);
     }
 
-    static int on_pipe_update(int fd, uint32_t mask, void *data) {
-        wayfire_hinge* that = (wayfire_hinge*) data;
+    static int on_pipe_update(int fd, uint32_t mask, void *data)
+    {
+        wayfire_hinge *that = (wayfire_hinge*)data;
         thread_message message;
         read(that->pipefd[0], &message, 1);
-        switch (message) {
-            case thread_message::ENABLE_INPUT: 
-                that->enable_inputs();
-                break;
-            case thread_message::DISABLE_INPUT: 
-                that->disable_inputs();
-                break;
-            case thread_message::THREAD_EXIT: 
-                that->enable_inputs(); // So we don't get stuck in an unusable state
-                return 0;
+        switch (message)
+        {
+          case thread_message::ENABLE_INPUT:
+            that->enable_inputs();
+            break;
+
+          case thread_message::DISABLE_INPUT:
+            that->disable_inputs();
+            break;
+
+          case thread_message::THREAD_EXIT:
+            that->enable_inputs(); // So we don't get stuck in an unusable state
+            return 0;
         }
+
         return 1;
     }
 
-    public:
+  public:
 
-        void init() override
+    void init() override
+    {
+        if (pipe(pipefd) == -1)
         {
-            if (pipe(pipefd) == -1) {
-               LOGE("Failed to open pipe");
-               return;
-            }
-            pipe_reader = wl_event_loop_add_fd(wl_display_get_event_loop(wf::get_core().display), pipefd[0], WL_EVENT_READABLE, on_pipe_update, this);
-            thread = std::thread(setup_thread, file_name.value(), poll_freq.value(), flip_degree.value(), &exiting, pipefd[1]);
+            LOGE("Failed to open pipe");
+            return;
         }
 
-        void fini() override
-        { 
-            enable_inputs();
-            wl_event_source_remove(pipe_reader);
+        pipe_reader =
+            wl_event_loop_add_fd(wl_display_get_event_loop(
+                wf::get_core().display), pipefd[0], WL_EVENT_READABLE, on_pipe_update,
+                this);
+        thread = std::thread(setup_thread, file_name.value(),
+            poll_freq.value(), flip_degree.value(), &exiting, pipefd[1]);
+    }
 
-            exiting = true;
-            thread.join();
+    void fini() override
+    {
+        enable_inputs();
+        wl_event_source_remove(pipe_reader);
 
-            close(pipefd[0]);
-        }
+        exiting = true;
+        thread.join();
+
+        close(pipefd[0]);
+    }
 };
 
 DECLARE_WAYFIRE_PLUGIN(wayfire_hinge);

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -1,6 +1,7 @@
-#include <wayfire/plugin.hpp>
-#include <wayfire/signal-definitions.hpp>
+#include "wayfire/plugin.hpp"
+#include "wayfire/signal-definitions.hpp"
 #include "wayfire/input-device.hpp"
+#include <wayfire/util/log.hpp>
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -24,7 +25,7 @@ class wayfire_hinge : public wf::plugin_interface_t
         device_file.readsome(buf, 4);
 
         if(device_file.fail()) {
-            perror("The following error occured while trying to read the hinge sensor data");
+            LOGE("Failed reading from hinge sensor device: ", device_file.rdstate());
             return false;
         }
         
@@ -32,7 +33,7 @@ class wayfire_hinge : public wf::plugin_interface_t
         sscanf(buf, "%i", &angle);
 
         if((angle < 0) | (angle > 360)) {
-            std::cout << "Read invalid data from hinge sensor: " << angle << std::endl;
+            LOGE("Read invalid data from hinge sensor: ", angle);
             enable_inputs(); // So we don't get stuck with disabled inputs
             return true;
         }

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -70,7 +70,6 @@ class wayfire_hinge : public wf::plugin_interface_t
                 LOGE("Failed reading from hinge sensor device: ",
                     device_file.rdstate());
                 send_message(thread_message::THREAD_EXIT, write_fd);
-                device_file.close();
                 break;
             }
 
@@ -79,7 +78,6 @@ class wayfire_hinge : public wf::plugin_interface_t
             {
                 LOGE("Read invalid data from hinge sensor: ", angle);
                 send_message(thread_message::THREAD_EXIT, write_fd);
-                device_file.close();
                 break;
             }
 

--- a/src/hinge.cpp
+++ b/src/hinge.cpp
@@ -5,54 +5,29 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <unistd.h>
+#include <thread>
 
 class wayfire_hinge : public wf::plugin_interface_t
 {
+    enum thread_message {
+        ENABLE_INPUT,
+        DISABLE_INPUT,
+        THREAD_EXIT
+    };
+
     wf::option_wrapper_t<std::string> file_name{"hinge/filename"};
     wf::option_wrapper_t<int> poll_freq{"hinge/poll_freq"};
     wf::option_wrapper_t<int> flip_degree{"hinge/flip_degree"};
     
-    std::ifstream device_file;
-    wf::wl_timer* timer;
-
-    bool input_enabled = true;
+    int pipefd[2];
 
     std::vector<nonstd::observer_ptr<wf::input_device_t>> get_inputs() {
         wf::compositor_core_t* core = &wf::get_core();
         return core->get_input_devices();
     }
 
-    bool read_device() 
-    {   
-        char buf[4];
-        device_file.seekg(0);
-        device_file.readsome(buf, 4);
-
-        if(device_file.fail()) {
-            LOGE("Failed reading from hinge sensor device: ", device_file.rdstate());
-            return false;
-        }
-        
-        int angle = std::stoi(buf);
-        if(angle < 0 || angle > 360) {
-            LOGE("Read invalid data from hinge sensor: ", angle);
-            enable_inputs(); // So we don't get stuck with disabled inputs
-            return true;
-        }
-
-        bool new_state = angle < flip_degree;
-        if(new_state != input_enabled) {
-            if(new_state) enable_inputs();
-            else disable_inputs();
-        }
-
-        return true;
-    }
-
-
-
     void disable_inputs() {
-        input_enabled = false;
         for (auto inp: get_inputs())
         {
             auto inp_type = inp->get_wlr_handle()->type;
@@ -66,30 +41,84 @@ class wayfire_hinge : public wf::plugin_interface_t
     }
 
     void enable_inputs() {
-        input_enabled = true;
         for (auto inp: get_inputs())
         {
             inp->set_enabled();
         }
     }
 
+    static void setup_thread(std::string fn, int poll_freq, int flip_degree, int pipe) {
+        std::ifstream device_file(fn, std::ifstream::in);
+        bool input_enabled = true;
+
+        while(true) {
+            char buf[4];
+            device_file.seekg(0);
+            device_file.readsome(buf, 4);
+
+            if(device_file.fail()) {
+                LOGE("Failed reading from hinge sensor device: ", device_file.rdstate());
+                send_message(thread_message::THREAD_EXIT, pipe);
+                device_file.close();
+                break;
+            }
+            
+            int angle = std::stoi(buf);
+            if(angle < 0 || angle > 360) {
+                LOGE("Read invalid data from hinge sensor: ", angle);
+                send_message(thread_message::THREAD_EXIT, pipe);
+                device_file.close();
+                break;
+            }
+
+            bool new_state = angle < flip_degree;
+            if(new_state != input_enabled) {
+                if(new_state) send_message(thread_message::ENABLE_INPUT, pipe);
+                else send_message(thread_message::DISABLE_INPUT, pipe);
+                input_enabled = new_state;
+            }
+            usleep(poll_freq * 1000); // microseconds*1000=ms
+        }
+    }
+
+    static void send_message(thread_message message, int pipe) {
+        write(pipe, (char*)&message, 1);
+    }
+
+    static int on_pipe_update(int fd, uint32_t mask, void *data) {
+        wayfire_hinge* that = (wayfire_hinge*) data;
+        thread_message message;
+        read(that->pipefd[0], &message, 1);
+        switch (message) {
+            case thread_message::ENABLE_INPUT: 
+                that->enable_inputs();
+                break;
+            case thread_message::DISABLE_INPUT: 
+                that->disable_inputs();
+                break;
+            case thread_message::THREAD_EXIT: 
+                that->enable_inputs(); // So we don't get stuck in an unusable state
+                return 0;
+        }
+        return 1;
+    }
+
     public:
 
         void init() override
         {
-            device_file.open(file_name, std::ifstream::in);
-
-            timer = new wf::wl_timer();
-            timer->set_timeout(poll_freq, [this] ()
-            {
-                return read_device();
-            });
+            if (pipe(pipefd) == -1) {
+               LOGE("Failed to open pipe");
+               return;
+            }
+            wl_event_loop_add_fd(wl_display_get_event_loop(wf::get_core().display), pipefd[0], WL_EVENT_READABLE, on_pipe_update, this);
+            std::thread thread(setup_thread, file_name.value(), poll_freq.value(), flip_degree.value(), pipefd[1]);
+            thread.detach();
         }
 
         void fini() override
         { 
             enable_inputs();
-            device_file.close();
         }
 };
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,6 +62,10 @@ workspace_names = shared_module('workspace-names', 'workspace-names.cpp',
     dependencies: [wayfire, wlroots, wfconfig, cairo],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
+workspace_names = shared_module('hinge', 'hinge.cpp',
+    dependencies: [wayfire, wlroots, wfconfig],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
 if get_option('enable_nk')
     subdir('network-keyboard')
 endif


### PR DESCRIPTION
Given a filename to a sensor device this plugin can disable keyboard and pointer inputs depending on the value read from the sensor. This is helpful in 2in1 convertible laptops when you want to use it in a 'tent' configuration for example.

I'm not well versed in C++, so please do suggest edits, if needed.