### PR TITLE
network-keyboard: Drop wlroots and wf-config dependencies

### DIFF
--- a/src/network-keyboard/meson.build
+++ b/src/network-keyboard/meson.build
@@ -4,8 +4,8 @@ gtkmm = dependency('gtkmm-3.0')
 xkbcommon = dependency('xkbcommon')
 
 nkserverexe = executable('wf-nk-server', 'server.cpp',
-    dependencies: [wayfire, wlroots, wfconfig, boost, pthread, gtkmm, wf_protos], install: true)
+    dependencies: [wayfire, boost, pthread, gtkmm, wf_protos], install: true)
 
 nkclientexe = executable('wf-nk-client', ['client.cpp', 'shared/os-compatibility.c'],
-    dependencies: [wayfire, wlroots, wfconfig, boost, pthread, wf_protos, xkbcommon], install: true)
+    dependencies: [wayfire, boost, pthread, wf_protos, xkbcommon], install: true)
 


### PR DESCRIPTION
These are now pulled in with wayfire.