### PR TITLE
follow-focus: also connect on pointer_motion_absolute events

### DIFF
--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -173,6 +173,7 @@ class wayfire_follow_focus : public wf::plugin_interface_t
         grab_interface->capabilities = 0;
 
         wf::get_core().connect_signal("pointer_motion", &pointer_motion);
+        wf::get_core().connect_signal("pointer_motion_absolute", &pointer_motion);
     }
 
     void fini() override


### PR DESCRIPTION
This makes it work with e.g. virtual machines where mouse may cause pointer_motion_absolute events only.