### PR TITLE
fsp: Ensure focus view is valid

### DIFF
--- a/src/focus-steal-prevent.cpp
+++ b/src/focus-steal-prevent.cpp
@@ -190,8 +190,23 @@ class wayfire_focus_steal_prevent : public wf::per_output_plugin_instance_t
         reset_timeout();
     };
 
+    void validate_last_focus_view()
+    {
+        for (auto & view : wf::get_core().get_all_views())
+        {
+            if (view == last_focus_view)
+            {
+                return;
+            }
+        }
+
+        last_focus_view = nullptr;
+    }
+
     wf::signal::connection_t<wf::pre_focus_view_signal> pre_view_focused = [=] (wf::pre_focus_view_signal *ev)
     {
+        validate_last_focus_view();
+
         if (ev->view && deny_focus_views.matches(ev->view))
         {
             ev->can_focus = false;


### PR DESCRIPTION
We might have a dangling pointer without making sure the view is one of the views in the core list before using it.