### PR TITLE
Update plugins for changes in Wayfire master

### DIFF
--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -27,9 +27,9 @@
 #include <numeric>
 #include <wayfire/plugin.hpp>
 #include <wayfire/output.hpp>
+#include <wayfire/workarea.hpp>
 #include <wayfire/render-manager.hpp>
 #include <wayfire/per-output-plugin.hpp>
-#include <wayfire/workspace-manager.hpp>
 #include <wayfire/plugins/common/cairo-util.hpp>
 
 extern "C"
@@ -116,7 +116,7 @@ class wayfire_bench_screen : public wf::per_output_plugin_instance_t
 
     void update_texture_position()
     {
-        auto workarea = output->workspace->get_workarea();
+        auto workarea = output->workarea->get_workarea();
 
         cairo_recreate();
 

--- a/src/focus-steal-prevent.cpp
+++ b/src/focus-steal-prevent.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <wayfire/per-output-plugin.hpp>
-#include <wayfire/workspace-manager.hpp>
+#include <wayfire/view-helpers.hpp>
 #include <wayfire/matcher.hpp>
 #include <set>
 #include <linux/input-event-codes.h>
@@ -39,7 +39,7 @@ class wayfire_focus_steal_prevent : public wf::per_output_plugin_instance_t
     int modifiers_pressed = 0;
     std::multiset<uint32_t> pressed_keys;
     std::multiset<uint32_t> cancel_keycodes;
-    wf::wl_timer timer;
+    wf::wl_timer<false> timer;
 
     wf::option_wrapper_t<int> timeout{"focus-steal-prevent/timeout"};
     wf::view_matcher_t deny_focus_views{"focus-steal-prevent/deny_focus_views"};
@@ -110,7 +110,6 @@ class wayfire_focus_steal_prevent : public wf::per_output_plugin_instance_t
         timer.set_timeout(timeout, [=] ()
         {
             cancel();
-            return false; // disconnect
         });
     }
 
@@ -212,7 +211,7 @@ class wayfire_focus_steal_prevent : public wf::per_output_plugin_instance_t
             ev->can_focus = false;
             if (last_focus_view)
             {
-                output->workspace->bring_to_front(last_focus_view);
+                wf::view_bring_to_front(last_focus_view);
             }
         }
 
@@ -230,7 +229,7 @@ class wayfire_focus_steal_prevent : public wf::per_output_plugin_instance_t
             if (focus_view)
             {
                 ev->can_focus = false;
-                output->workspace->bring_to_front(focus_view);
+                wf::view_bring_to_front(focus_view);
             }
 
             if (ev->view)

--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -26,11 +26,10 @@
 #include <wayfire/option-wrapper.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/output-layout.hpp>
-#include <wayfire/workspace-manager.hpp>
 #include <wayfire/per-output-plugin.hpp>
+#include <wayfire/view-helpers.hpp>
 #include <wayfire/view.hpp>
 #include <wayfire/util.hpp>
-
 
 namespace follow_focus
 {
@@ -41,7 +40,7 @@ class wayfire_follow_focus : public wf::per_output_plugin_instance_t
 {
   private:
     wayfire_view focus_view = nullptr;
-    wf::wl_timer change_output_focus, change_view_focus;
+    wf::wl_timer<false> change_output_focus, change_view_focus;
     wf::point_t last_output_coords, last_view_coords;
 
     wf::option_wrapper_t<bool> should_change_view{"follow-focus/change_view"};
@@ -129,7 +128,7 @@ class wayfire_follow_focus : public wf::per_output_plugin_instance_t
         }
 
         if (!view || (view->role != wf::VIEW_ROLE_TOPLEVEL) ||
-            (output->workspace->get_view_layer(view) != wf::LAYER_WORKSPACE))
+            (wf::get_view_layer(view) != wf::scene::layer::WORKSPACE))
         {
             return;
         }

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -33,7 +33,7 @@ bool hidden;
 class wayfire_hide_cursor
 {
     wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
-    wf::wl_timer hide_timer;
+    wf::wl_timer<false> hide_timer;
 
   public:
     wayfire_hide_cursor()
@@ -64,8 +64,6 @@ class wayfire_hide_cursor
                 wf::get_core().hide_cursor();
                 hidden = true;
             }
-
-            return false; // disconnect
         });
     }
 

--- a/src/join-views.cpp
+++ b/src/join-views.cpp
@@ -1,6 +1,7 @@
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/per-output-plugin.hpp>
 #include <wayfire/plugins/common/shared-core-data.hpp>
+#include <wayfire/toplevel-view.hpp>
 
 class JoinViewsSingleton
 {
@@ -8,18 +9,18 @@ class JoinViewsSingleton
     wf::signal::connection_t<wf::view_geometry_changed_signal> on_geometry_changed{[=
         ] (wf::view_geometry_changed_signal *ev)
         {
-            auto view = ev->view;
-            if (!view->is_mapped())
+            auto view = wf::toplevel_cast(ev->view);
+            if (!view || !view->is_mapped())
             {
                 return;
             }
 
-            auto parent_geometry = view->get_wm_geometry();
+            auto parent_geometry = view->get_pending_geometry();
             int cx = parent_geometry.x + parent_geometry.width / 2;
             int cy = parent_geometry.y + parent_geometry.height / 2;
             for (auto child : view->children)
             {
-                auto target = child->get_wm_geometry();
+                auto target = child->get_pending_geometry();
                 target.x = cx - target.width / 2;
                 target.y = cy - target.height / 2;
                 child->set_geometry(target);

--- a/src/keycolor.cpp
+++ b/src/keycolor.cpp
@@ -27,7 +27,6 @@
 #include <wayfire/plugin.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/view-transform.hpp>
-#include <wayfire/workspace-manager.hpp>
 #include <wayfire/per-output-plugin.hpp>
 #include <wayfire/signal-definitions.hpp>
 
@@ -146,7 +145,7 @@ class simple_node_render_instance_t : public wf::scene::transformer_render_insta
         wlr_box fb_geom =
             target.framebuffer_box_from_geometry_box(target.geometry);
         auto view_box = target.framebuffer_box_from_geometry_box(
-            this->view->get_wm_geometry());
+            self->get_children_bounding_box());
         view_box.x -= fb_geom.x;
         view_box.y -= fb_geom.y;
 
@@ -238,7 +237,7 @@ class wf_keycolor : public wf::scene::view_2d_transformer_t
     {}
 };
 
-class wayfire_keycolor : public wf::per_output_plugin_instance_t
+class wayfire_keycolor : public wf::plugin_interface_t
 {
     wf::wl_idle_call idle_attach;
     const std::string transformer_name = "keycolor";
@@ -266,7 +265,7 @@ class wayfire_keycolor : public wf::per_output_plugin_instance_t
 
     void remove_transformers()
     {
-        for (auto& view : output->workspace->get_views_in_layer(wf::ALL_LAYERS))
+        for (auto& view : wf::get_core().get_all_views())
         {
             pop_transformer(view);
         }
@@ -289,9 +288,9 @@ class wayfire_keycolor : public wf::per_output_plugin_instance_t
 
         program_ref_count++;
 
-        output->connect(&view_attached);
+        wf::get_core().connect(&on_view_map);
 
-        for (auto& view : output->workspace->get_views_in_layer(wf::ALL_LAYERS))
+        for (auto& view : wf::get_core().get_all_views())
         {
             if (view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT)
             {
@@ -302,29 +301,26 @@ class wayfire_keycolor : public wf::per_output_plugin_instance_t
         }
     }
 
-    wf::signal::connection_t<wf::view_layer_attached_signal> view_attached{[this] (wf::
-                                                                                   view_layer_attached_signal
-                                                                                   *ev)
+    wf::signal::connection_t<wf::view_mapped_signal> on_view_map = [=] (wf::view_mapped_signal *ev)
+    {
+        auto view = ev->view;
+        if (!view)
         {
-            auto view = ev->view;
-            if (!view)
-            {
-                return;
-            }
-
-            if (view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT)
-            {
-                return;
-            }
-
-            idle_attach.run_once([=] ()
-            {
-                if (!view->get_transformed_node()->get_transformer(transformer_name))
-                {
-                    add_transformer(view);
-                }
-            });
+            return;
         }
+
+        if (view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT)
+        {
+            return;
+        }
+
+        idle_attach.run_once([=] ()
+        {
+            if (!view->get_transformed_node()->get_transformer(transformer_name))
+            {
+                add_transformer(view);
+            }
+        });
     };
 
     void fini() override
@@ -349,7 +345,7 @@ class wayfire_keycolor : public wf::per_output_plugin_instance_t
     }
 };
 
-DECLARE_WAYFIRE_PLUGIN(wf::per_output_plugin_t<wayfire_keycolor>);
 }
 }
 }
+DECLARE_WAYFIRE_PLUGIN(wf::scene::keycolor::wayfire_keycolor);

--- a/src/keycolor.cpp
+++ b/src/keycolor.cpp
@@ -344,8 +344,8 @@ class wayfire_keycolor : public wf::plugin_interface_t
         wf::get_core().erase_data(program_name);
     }
 };
+}
+}
+}
 
-}
-}
-}
 DECLARE_WAYFIRE_PLUGIN(wf::scene::keycolor::wayfire_keycolor);

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
-#annotate = shared_module('annotate', 'annotate.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+annotate = shared_module('annotate', 'annotate.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 if giomm.found()
 autorotate = shared_module('autorotate-iio', 'autorotate-iio.cpp',
@@ -16,9 +16,9 @@ benchmark = shared_module('bench', 'bench.cpp',
     dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-#crosshair = shared_module('crosshair', 'crosshair.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+crosshair = shared_module('crosshair', 'crosshair.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 focus_steal_prevent = shared_module('focus-steal-prevent', 'focus-steal-prevent.cpp',
     dependencies: [wayfire],
@@ -38,45 +38,45 @@ glib_main_loop = shared_module('glib-main-loop', 'glib-main-loop.cpp',
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 endif
 
-#hide_cursor = shared_module('hide-cursor', 'hide-cursor.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+hide_cursor = shared_module('hide-cursor', 'hide-cursor.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-#joinviews = shared_module('join-views', 'join-views.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-#
-#keycolor = shared_module('keycolor', 'keycolor.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+joinviews = shared_module('join-views', 'join-views.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
+keycolor = shared_module('keycolor', 'keycolor.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 magnifier = shared_module('mag', 'mag.cpp',
     dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-#showrepaint = shared_module('showrepaint', 'showrepaint.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-#
-#view_shot = shared_module('view-shot', 'view-shot.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-#
-#water = shared_module('water', 'water.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-#
-#window_zoom = shared_module('winzoom', 'window-zoom.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-#
-#workspace_names = shared_module('workspace-names', 'workspace-names.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-#
-#hinge = shared_module('hinge', 'hinge.cpp',
-#    dependencies: [wayfire],
-#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+showrepaint = shared_module('showrepaint', 'showrepaint.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
+view_shot = shared_module('view-shot', 'view-shot.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
+water = shared_module('water', 'water.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
+window_zoom = shared_module('winzoom', 'window-zoom.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
+workspace_names = shared_module('workspace-names', 'workspace-names.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
+hinge = shared_module('hinge', 'hinge.cpp',
+    dependencies: [wayfire],
+    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 if get_option('enable_nk')
     subdir('network-keyboard')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
-annotate = shared_module('annotate', 'annotate.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#annotate = shared_module('annotate', 'annotate.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 if giomm.found()
 autorotate = shared_module('autorotate-iio', 'autorotate-iio.cpp',
@@ -8,17 +8,17 @@ autorotate = shared_module('autorotate-iio', 'autorotate-iio.cpp',
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 endif
 
-background_view = shared_module('background-view', 'background-view.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#background_view = shared_module('background-view', 'background-view.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 benchmark = shared_module('bench', 'bench.cpp',
     dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-crosshair = shared_module('crosshair', 'crosshair.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#crosshair = shared_module('crosshair', 'crosshair.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 focus_steal_prevent = shared_module('focus-steal-prevent', 'focus-steal-prevent.cpp',
     dependencies: [wayfire],
@@ -28,9 +28,9 @@ follow_focus = shared_module('follow-focus', 'follow-focus.cpp',
     dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-force_fullscreen = shared_module('force-fullscreen', 'force-fullscreen.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#force_fullscreen = shared_module('force-fullscreen', 'force-fullscreen.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 if giomm.found()
 glib_main_loop = shared_module('glib-main-loop', 'glib-main-loop.cpp',
@@ -38,45 +38,45 @@ glib_main_loop = shared_module('glib-main-loop', 'glib-main-loop.cpp',
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 endif
 
-hide_cursor = shared_module('hide-cursor', 'hide-cursor.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#hide_cursor = shared_module('hide-cursor', 'hide-cursor.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-joinviews = shared_module('join-views', 'join-views.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-
-keycolor = shared_module('keycolor', 'keycolor.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#joinviews = shared_module('join-views', 'join-views.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#
+#keycolor = shared_module('keycolor', 'keycolor.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 magnifier = shared_module('mag', 'mag.cpp',
     dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-showrepaint = shared_module('showrepaint', 'showrepaint.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-
-view_shot = shared_module('view-shot', 'view-shot.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-
-water = shared_module('water', 'water.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-
-window_zoom = shared_module('winzoom', 'window-zoom.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-
-workspace_names = shared_module('workspace-names', 'workspace-names.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-
-hinge = shared_module('hinge', 'hinge.cpp',
-    dependencies: [wayfire],
-    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#showrepaint = shared_module('showrepaint', 'showrepaint.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#
+#view_shot = shared_module('view-shot', 'view-shot.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#
+#water = shared_module('water', 'water.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#
+#window_zoom = shared_module('winzoom', 'window-zoom.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#
+#workspace_names = shared_module('workspace-names', 'workspace-names.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+#
+#hinge = shared_module('hinge', 'hinge.cpp',
+#    dependencies: [wayfire],
+#    install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 if get_option('enable_nk')
     subdir('network-keyboard')

--- a/src/view-shot.cpp
+++ b/src/view-shot.cpp
@@ -72,7 +72,8 @@ class wayfire_view_shot : public wf::per_output_plugin_instance_t
             return false;
         }
 
-        const wf::render_target_t& offscreen_buffer = view->take_snapshot();
+        wf::render_target_t offscreen_buffer;
+        view->take_snapshot(offscreen_buffer);
         auto width  = offscreen_buffer.viewport_width;
         auto height = offscreen_buffer.viewport_height;
 
@@ -86,8 +87,8 @@ class wayfire_view_shot : public wf::per_output_plugin_instance_t
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, offscreen_buffer.fb));
         GL_CALL(glViewport(0, 0, width, height));
 
-        GL_CALL(glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
-            pixels));
+        GL_CALL(glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
+        offscreen_buffer.release(); // free gpu memory
         OpenGL::render_end();
 
         char _file_name[255];
@@ -96,8 +97,7 @@ class wayfire_view_shot : public wf::per_output_plugin_instance_t
             file_name.value().c_str(), std::localtime(&time));
         std::string formatted_file_name = _file_name;
 
-        image_io::write_to_file(formatted_file_name, pixels, width, height, "png",
-            true);
+        image_io::write_to_file(formatted_file_name, pixels, width, height, "png", true);
         free(pixels);
 
         wf::get_core().run(replaceAll(command, "%f", formatted_file_name));

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -194,7 +194,7 @@ class wayfire_water_screen : public wf::per_output_plugin_instance_t, public wf:
     wf::pointf_t last_cursor;
     bool button_down = false;
     bool hook_set    = false;
-    wf::wl_timer timer;
+    wf::wl_timer<false> timer;
     int points_loc;
     std::unique_ptr<wf::input_grab_t> input_grab;
     wf::plugin_activation_data_t grab_interface{
@@ -253,17 +253,17 @@ class wayfire_water_screen : public wf::per_output_plugin_instance_t, public wf:
 
         last_cursor = output->get_cursor_position();
         animation.animate(animation, 1);
-        input_grab->grab_input(wf::scene::layer::OVERLAY, true);
+        input_grab->grab_input(wf::scene::layer::OVERLAY);
+        input_grab->set_wants_raw_input(true);
         timer.disconnect();
         button_down = true;
 
         return false;
     };
 
-    wf::wl_timer::callback_t timeout = [=] ()
+    wf::wl_timer<false>::callback_t timeout = [=] ()
     {
         animation.animate(animation, 0);
-        return false; // disconnect
     };
 
     wf::post_hook_t render = [=] (const wf::framebuffer_t& source,

--- a/src/window-zoom.cpp
+++ b/src/window-zoom.cpp
@@ -23,12 +23,15 @@
  */
 
 #include <wayfire/core.hpp>
+#include <wayfire/scene.hpp>
+#include <wayfire/toplevel-view.hpp>
+#include <wayfire/view-helpers.hpp>
 #include <wayfire/view.hpp>
 #include <wayfire/plugin.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/render-manager.hpp>
 #include <wayfire/view-transform.hpp>
-#include <wayfire/workspace-manager.hpp>
+#include <wayfire/workspace-set.hpp>
 #include <wayfire/per-output-plugin.hpp>
 
 
@@ -55,7 +58,7 @@ class simple_node_render_instance_t : public transformer_render_instance_t<node_
     };
 
     node_t *self;
-    wayfire_view view;
+    wayfire_toplevel_view view;
     float *scale_x, *scale_y;
     wlr_box *transformed_view_geometry;
     damage_callback push_damage;
@@ -63,7 +66,7 @@ class simple_node_render_instance_t : public transformer_render_instance_t<node_
 
   public:
     simple_node_render_instance_t(node_t *self, damage_callback push_damage,
-        wayfire_view view, float *scale_x, float *scale_y,
+        wayfire_toplevel_view view, float *scale_x, float *scale_y,
         wlr_box *transformed_view_geometry) :
         transformer_render_instance_t<node_t>(self, push_damage,
             view->get_output())
@@ -86,7 +89,7 @@ class simple_node_render_instance_t : public transformer_render_instance_t<node_
 
     void schedule_instructions(
         std::vector<render_instruction_t>& instructions,
-        const wf::render_target_t& target, wf::region_t& damage)
+        const wf::render_target_t& target, wf::region_t& damage) override
     {
         // We want to render ourselves only, the node does not have children
         instructions.push_back(render_instruction_t{
@@ -103,7 +106,7 @@ class simple_node_render_instance_t : public transformer_render_instance_t<node_
 
     wlr_box get_scaled_geometry()
     {
-        auto vg = view->get_wm_geometry();
+        auto vg = view->get_geometry();
         auto midpoint = get_center(vg);
         auto result   = wf::pointf_t{float(vg.x), float(vg.y)} - midpoint;
         result.x *= *scale_x;
@@ -117,7 +120,7 @@ class simple_node_render_instance_t : public transformer_render_instance_t<node_
     }
 
     void render(const wf::render_target_t& target,
-        const wf::region_t& region)
+        const wf::region_t& region) override
     {
         auto src_tex = transformer_render_instance_t<node_t>::get_texture(1.0);
 
@@ -140,14 +143,14 @@ class simple_node_render_instance_t : public transformer_render_instance_t<node_
 
 class winzoom_t : public view_2d_transformer_t
 {
-    wayfire_view view;
+    wayfire_toplevel_view view;
     wlr_box transformed_view_geometry;
 
   public:
-    winzoom_t(wayfire_view view) : view_2d_transformer_t(view)
+    winzoom_t(wayfire_toplevel_view view) : view_2d_transformer_t(view)
     {
         this->view = view;
-        this->transformed_view_geometry = view->get_wm_geometry();
+        this->transformed_view_geometry = view->get_geometry();
     }
 
     wf::pointf_t to_local(const wf::pointf_t& point) override
@@ -205,7 +208,7 @@ class wayfire_winzoom : public wf::per_output_plugin_instance_t
         output->add_activator(dec_y_binding, &on_dec_y);
     }
 
-    bool update_winzoom(wayfire_view view, wf::point_t delta)
+    bool update_winzoom(wayfire_toplevel_view view, wf::point_t delta)
     {
         winzoom_t *transformer;
         wf::pointf_t zoom;
@@ -222,9 +225,8 @@ class wayfire_winzoom : public wf::per_output_plugin_instance_t
 
         output->deactivate_plugin(&grab_interface);
 
-        auto layer = output->workspace->get_view_layer(view);
-
-        if (layer & (wf::LAYER_BACKGROUND | wf::LAYER_TOP))
+        auto layer = wf::get_view_layer(view);
+        if (layer == wf::scene::layer::BACKGROUND || layer == wf::scene::layer::TOP)
         {
             return false;
         }
@@ -290,31 +292,31 @@ class wayfire_winzoom : public wf::per_output_plugin_instance_t
 
     wf::activator_callback on_inc_x = [=] (auto)
     {
-        auto view = output->get_active_view();
+        auto view = toplevel_cast(output->get_active_view());
         return update_winzoom(view, wf::point_t{1, 0});
     };
 
     wf::activator_callback on_dec_x = [=] (auto)
     {
-        auto view = output->get_active_view();
+        auto view = toplevel_cast(output->get_active_view());
         return update_winzoom(view, wf::point_t{-1, 0});
     };
 
     wf::activator_callback on_inc_y = [=] (auto)
     {
-        auto view = output->get_active_view();
+        auto view = toplevel_cast(output->get_active_view());
         return update_winzoom(view, wf::point_t{0, 1});
     };
 
     wf::activator_callback on_dec_y = [=] (auto)
     {
-        auto view = output->get_active_view();
+        auto view = toplevel_cast(output->get_active_view());
         return update_winzoom(view, wf::point_t{0, -1});
     };
 
     wf::axis_callback axis_cb = [=] (wlr_pointer_axis_event *ev)
     {
-        auto view = wf::get_core().get_cursor_focus_view();
+        auto view = toplevel_cast(wf::get_core().get_cursor_focus_view());
         if (ev->orientation == WLR_AXIS_ORIENTATION_VERTICAL)
         {
             auto delta = (int)-std::clamp(ev->delta, -1.0, 1.0);

--- a/src/window-zoom.cpp
+++ b/src/window-zoom.cpp
@@ -226,7 +226,7 @@ class wayfire_winzoom : public wf::per_output_plugin_instance_t
         output->deactivate_plugin(&grab_interface);
 
         auto layer = wf::get_view_layer(view);
-        if (layer == wf::scene::layer::BACKGROUND || layer == wf::scene::layer::TOP)
+        if ((layer == wf::scene::layer::BACKGROUND) || (layer == wf::scene::layer::TOP))
         {
             return false;
         }


### PR DESCRIPTION
I have updated most of the plugins, force-fullscreen and background-view may need a bit more work, but I am not in the mood for them right now :)

In general, we need a proper solution for sticky views (which is needed for background-view), because currently Wayfire draws sticky views only on one workspace.
Layer-shell views are hacked to work, but not very well (for example blur does not work with wf-panel in Expo). I will be working on a fix for wayfire soon.
In the meantime, I figured it will likely be best to update the rest of the plugins so that people that want them can use them.

@soreau I am not sure whether you are available, so if you do not respond in a week, I will just merge this PR.
