### PR TITLE
view-shot: Remove activator binding on fini

### DIFF
--- a/src/view-shot.cpp
+++ b/src/view-shot.cpp
@@ -106,7 +106,9 @@ class wayfire_view_shot : public wf::per_output_plugin_instance_t
     };
 
     void fini() override
-    {}
+    {
+        output->rem_binding(&on_capture);
+    }
 };
 
 DECLARE_WAYFIRE_PLUGIN(wf::per_output_plugin_t<wayfire_view_shot>);


### PR DESCRIPTION
Otherwise, disabling the plugin and running the binding will cause a crash.