### PR TITLE
build: check dependency libevdev

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ wayfire = dependency('wayfire')
 giomm = dependency('giomm-2.4', required: false)
 wayland_protos = dependency('wayland-protocols', version: '>=1.12')
 wayland_server = dependency('wayland-server')
+evdev = dependency('libevdev')
 
 if get_option('enable_windecor') == true
     windecor = subproject('windecor')

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,7 +21,7 @@ crosshair = shared_module('crosshair', 'crosshair.cpp',
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 focus_steal_prevent = shared_module('focus-steal-prevent', 'focus-steal-prevent.cpp',
-    dependencies: [wayfire],
+    dependencies: [wayfire, evdev],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
 follow_focus = shared_module('follow-focus', 'follow-focus.cpp',


### PR DESCRIPTION
Fix build in NixOS
```
../src/focus-steal-prevent.cpp:28:10: fatal error: libevdev/libevdev.h: No such file or directory
   28 | #include <libevdev/libevdev.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```