### PR TITLE
follow-focus: check whether a focused view is there in the timer handler

### DIFF
--- a/src/follow-focus.cpp
+++ b/src/follow-focus.cpp
@@ -53,11 +53,13 @@ class wayfire_follow_focus : public wf::per_output_plugin_instance_t
     void change_view()
     {
         auto view = wf::get_core().get_cursor_focus_view();
-
-        wf::get_core().seat->focus_view(view);
-        if (raise_on_top)
+        if (view)
         {
-            view_bring_to_front(view);
+            wf::get_core().seat->focus_view(view);
+            if (raise_on_top)
+            {
+                view_bring_to_front(view);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #202 