### PR TITLE
fsp: Cancel fsp when clicking on desktop environment views

### DIFF
--- a/src/focus-steal-prevent.cpp
+++ b/src/focus-steal-prevent.cpp
@@ -185,6 +185,14 @@ class wayfire_focus_steal_prevent : public wf::per_output_plugin_instance_t
             return;
         }
 
+        auto view = wf::get_core().get_cursor_focus_view();
+        if ((!view || (view && (view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT))) &&
+            (ev->event->state == WLR_BUTTON_PRESSED) && prevent_focus_steal)
+        {
+            cancel();
+            return;
+        }
+
         focus_view = wf::get_core().get_cursor_focus_view();
         reset_timeout();
     };


### PR DESCRIPTION
This makes it so a user can focus a view from a window-list in a panel and also cancels fsp when clicking on any view that is of type desktop environment, or a place where there is no view or background.