### PR TITLE
json: switch to yyjson

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libdisplay-info-dev hwdata-dev yyjson boost-dev
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libdisplay-info-dev hwdata-dev yyjson-dev boost-dev
     - name: Wayfire
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland libdisplay-info-dev hwdata-dev yyjson boost-dev
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland libdisplay-info-dev hwdata-dev yyjson-dev boost-dev
     - name: Wayfire
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libdisplay-info-dev hwdata-dev nlohmann-json boost-dev
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libdisplay-info-dev hwdata-dev yyjson boost-dev
     - name: Wayfire
       uses: actions/checkout@v2
       with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland libdisplay-info-dev hwdata-dev nlohmann-json boost-dev
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev glibmm-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland libdisplay-info-dev hwdata-dev yyjson boost-dev
     - name: Wayfire
       uses: actions/checkout@v2
       with:

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ giomm = dependency('giomm-2.4', required: false)
 wayland_protos = dependency('wayland-protocols', version: '>=1.12')
 wayland_server = dependency('wayland-server')
 evdev = dependency('libevdev')
-json = dependency('nlohmann_json', required: false)
+json = dependency('yyjson', required: false)
 
 if get_option('enable_wayfire_shadows') == true
     wayfire_shadows = subproject('wayfire-shadows')

--- a/src/obs.cpp
+++ b/src/obs.cpp
@@ -412,17 +412,17 @@ class wayfire_obs : public wf::plugin_interface_t
         }
     }
 
-    wf::ipc::method_callback ipc_set_view_opacity = [=] (nlohmann::json data) -> nlohmann::json
+    wf::ipc::method_callback ipc_set_view_opacity = [=] (wf::json_t data) -> wf::json_t
     {
-        WFJSON_EXPECT_FIELD(data, "view-id", number_unsigned);
-        WFJSON_EXPECT_FIELD(data, "opacity", number);
-        WFJSON_EXPECT_FIELD(data, "duration", number);
+        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto opacity = wf::ipc::json_get_double(data, "opacity");
+        auto duration = wf::ipc::json_get_uint64(data, "duration");
 
-        auto view = wf::ipc::find_view_by_id(data["view-id"]);
+        auto view = wf::ipc::find_view_by_id(view_id);
         if (view && view->is_mapped())
         {
             ensure_transformer(view);
-            adjust_opacity(view, data["opacity"], data["duration"]);
+            adjust_opacity(view, opacity, duration);
         } else
         {
             return wf::ipc::json_error("Failed to find view with given id. Maybe it was closed?");
@@ -431,17 +431,18 @@ class wayfire_obs : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback ipc_set_view_brightness = [=] (nlohmann::json data) -> nlohmann::json
+    wf::ipc::method_callback ipc_set_view_brightness = [=] (wf::json_t data) -> wf::json_t
     {
-        WFJSON_EXPECT_FIELD(data, "view-id", number_unsigned);
-        WFJSON_EXPECT_FIELD(data, "brightness", number);
-        WFJSON_EXPECT_FIELD(data, "duration", number);
+        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto brightness = wf::ipc::json_get_double(data, "brightness");
+        auto duration = wf::ipc::json_get_uint64(data, "duration");
 
-        auto view = wf::ipc::find_view_by_id(data["view-id"]);
+
+        auto view = wf::ipc::find_view_by_id(view_id);
         if (view && view->is_mapped())
         {
             ensure_transformer(view);
-            adjust_brightness(view, data["brightness"], data["duration"]);
+            adjust_brightness(view, brightness, duration);
         } else
         {
             return wf::ipc::json_error("Failed to find view with given id. Maybe it was closed?");
@@ -450,17 +451,17 @@ class wayfire_obs : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback ipc_set_view_saturation = [=] (nlohmann::json data) -> nlohmann::json
+    wf::ipc::method_callback ipc_set_view_saturation = [=] (wf::json_t data) -> wf::json_t
     {
-        WFJSON_EXPECT_FIELD(data, "view-id", number_unsigned);
-        WFJSON_EXPECT_FIELD(data, "saturation", number);
-        WFJSON_EXPECT_FIELD(data, "duration", number);
+        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto saturation = wf::ipc::json_get_double(data, "saturation");
+        auto duration = wf::ipc::json_get_uint64(data, "duration");
 
-        auto view = wf::ipc::find_view_by_id(data["view-id"]);
+        auto view = wf::ipc::find_view_by_id(view_id);
         if (view && view->is_mapped())
         {
             ensure_transformer(view);
-            adjust_saturation(view, data["saturation"], data["duration"]);
+            adjust_saturation(view, saturation, duration);
         } else
         {
             return wf::ipc::json_error("Failed to find view with given id. Maybe it was closed?");

--- a/src/obs.cpp
+++ b/src/obs.cpp
@@ -414,8 +414,8 @@ class wayfire_obs : public wf::plugin_interface_t
 
     wf::ipc::method_callback ipc_set_view_opacity = [=] (wf::json_t data) -> wf::json_t
     {
-        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
-        auto opacity = wf::ipc::json_get_double(data, "opacity");
+        auto view_id  = wf::ipc::json_get_uint64(data, "view-id");
+        auto opacity  = wf::ipc::json_get_double(data, "opacity");
         auto duration = wf::ipc::json_get_uint64(data, "duration");
 
         auto view = wf::ipc::find_view_by_id(view_id);
@@ -433,10 +433,9 @@ class wayfire_obs : public wf::plugin_interface_t
 
     wf::ipc::method_callback ipc_set_view_brightness = [=] (wf::json_t data) -> wf::json_t
     {
-        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto view_id    = wf::ipc::json_get_uint64(data, "view-id");
         auto brightness = wf::ipc::json_get_double(data, "brightness");
-        auto duration = wf::ipc::json_get_uint64(data, "duration");
-
+        auto duration   = wf::ipc::json_get_uint64(data, "duration");
 
         auto view = wf::ipc::find_view_by_id(view_id);
         if (view && view->is_mapped())
@@ -453,9 +452,9 @@ class wayfire_obs : public wf::plugin_interface_t
 
     wf::ipc::method_callback ipc_set_view_saturation = [=] (wf::json_t data) -> wf::json_t
     {
-        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto view_id    = wf::ipc::json_get_uint64(data, "view-id");
         auto saturation = wf::ipc::json_get_double(data, "saturation");
-        auto duration = wf::ipc::json_get_uint64(data, "duration");
+        auto duration   = wf::ipc::json_get_uint64(data, "duration");
 
         auto view = wf::ipc::find_view_by_id(view_id);
         if (view && view->is_mapped())

--- a/src/pin-view.cpp
+++ b/src/pin-view.cpp
@@ -69,8 +69,8 @@ class wayfire_pin_view : public wf::plugin_interface_t
         auto layer_str = wf::ipc::json_get_string(data, "layer");
         auto resize = wf::ipc::json_get_bool(data, "resize");
         /* workspace x,y */
-        auto maybe_x = wf::ipc::json_get_optional_uint64(data, "x");
-        auto maybe_y = wf::ipc::json_get_optional_uint64(data, "y");
+        auto optional_x = wf::ipc::json_get_optional_uint64(data, "x");
+        auto optional_y = wf::ipc::json_get_optional_uint64(data, "y");
 
         auto view = wf::ipc::find_view_by_id(view_id);
         if (view)
@@ -122,18 +122,17 @@ class wayfire_pin_view : public wf::plugin_interface_t
             }
 
             auto pvd = view->get_data<pin_view_data>();
-            bool resize = resize;
             auto og = output->get_relative_geometry();
             int x = 0, y = 0;
             wf::view_unmapped_signal unmap_signal;
             unmap_signal.view = view;
             wf::get_core().emit(&unmap_signal);
-            if (maybe_x.has_value())
+            if (optional_x.has_value())
             {
-                x = maybe_x.value();
-                if (maybe_y.has_value())
+                x = optional_x.value();
+                if (optional_y.has_value())
                 {
-                    y = maybe_y.value();
+                    y = optional_y.value();
                 }
 
                 view->role = pvd->role;

--- a/src/pin-view.cpp
+++ b/src/pin-view.cpp
@@ -65,9 +65,9 @@ class wayfire_pin_view : public wf::plugin_interface_t
 
     wf::ipc::method_callback ipc_pin_view = [=] (wf::json_t data) -> wf::json_t
     {
-        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto view_id   = wf::ipc::json_get_uint64(data, "view-id");
         auto layer_str = wf::ipc::json_get_string(data, "layer");
-        auto resize = wf::ipc::json_get_bool(data, "resize");
+        auto resize    = wf::ipc::json_get_bool(data, "resize");
         /* workspace x,y */
         auto optional_x = wf::ipc::json_get_optional_uint64(data, "x");
         auto optional_y = wf::ipc::json_get_optional_uint64(data, "y");

--- a/src/pin-view.cpp
+++ b/src/pin-view.cpp
@@ -63,16 +63,16 @@ class wayfire_pin_view : public wf::plugin_interface_t
         }
     }
 
-    wf::ipc::method_callback ipc_pin_view = [=] (nlohmann::json data) -> nlohmann::json
+    wf::ipc::method_callback ipc_pin_view = [=] (wf::json_t data) -> wf::json_t
     {
-        WFJSON_EXPECT_FIELD(data, "view-id", number_unsigned);
-        WFJSON_EXPECT_FIELD(data, "layer", string);
-        WFJSON_EXPECT_FIELD(data, "resize", boolean);
+        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto layer_str = wf::ipc::json_get_string(data, "layer");
+        auto resize = wf::ipc::json_get_bool(data, "resize");
         /* workspace x,y */
-        WFJSON_OPTIONAL_FIELD(data, "x", number_unsigned);
-        WFJSON_OPTIONAL_FIELD(data, "y", number_unsigned);
+        auto maybe_x = wf::ipc::json_get_optional_uint64(data, "x");
+        auto maybe_y = wf::ipc::json_get_optional_uint64(data, "y");
 
-        auto view = wf::ipc::find_view_by_id(data["view-id"]);
+        auto view = wf::ipc::find_view_by_id(view_id);
         if (view)
         {
             bool was_pinned = unpin(view);
@@ -95,25 +95,25 @@ class wayfire_pin_view : public wf::plugin_interface_t
             }
 
             wf::scene::layer layer;
-            if (data["layer"] == "background")
+            if (layer_str == "background")
             {
                 layer = wf::scene::layer::BACKGROUND;
-            } else if (data["layer"] == "bottom")
+            } else if (layer_str == "bottom")
             {
                 layer = wf::scene::layer::BOTTOM;
-            } else if (data["layer"] == "workspace")
+            } else if (layer_str == "workspace")
             {
                 layer = wf::scene::layer::WORKSPACE;
-            } else if (data["layer"] == "top")
+            } else if (layer_str == "top")
             {
                 layer = wf::scene::layer::TOP;
-            } else if (data["layer"] == "unmanaged")
+            } else if (layer_str == "unmanaged")
             {
                 layer = wf::scene::layer::UNMANAGED;
-            } else if (data["layer"] == "overlay")
+            } else if (layer_str == "overlay")
             {
                 layer = wf::scene::layer::OVERLAY;
-            } else if (data["layer"] == "lock")
+            } else if (layer_str == "lock")
             {
                 layer = wf::scene::layer::LOCK;
             } else
@@ -122,18 +122,18 @@ class wayfire_pin_view : public wf::plugin_interface_t
             }
 
             auto pvd = view->get_data<pin_view_data>();
-            bool resize = data["resize"];
+            bool resize = resize;
             auto og = output->get_relative_geometry();
             int x = 0, y = 0;
             wf::view_unmapped_signal unmap_signal;
             unmap_signal.view = view;
             wf::get_core().emit(&unmap_signal);
-            if (data.contains("x"))
+            if (maybe_x.has_value())
             {
-                x = data["x"].get<int>();
-                if (data.contains("y"))
+                x = maybe_x.value();
+                if (maybe_y.has_value())
                 {
-                    y = data["y"].get<int>();
+                    y = maybe_y.value();
                 }
 
                 view->role = pvd->role;
@@ -206,11 +206,11 @@ class wayfire_pin_view : public wf::plugin_interface_t
         return false;
     }
 
-    wf::ipc::method_callback ipc_unpin_view = [=] (nlohmann::json data) -> nlohmann::json
+    wf::ipc::method_callback ipc_unpin_view = [=] (wf::json_t data) -> wf::json_t
     {
-        WFJSON_EXPECT_FIELD(data, "view-id", number_unsigned);
+        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
 
-        auto view = wf::ipc::find_view_by_id(data["view-id"]);
+        auto view = wf::ipc::find_view_by_id(view_id);
         if (!unpin(view))
         {
             LOGE("Failed to find view with given id. Perhaps it is not pinned.");

--- a/src/view-shot.cpp
+++ b/src/view-shot.cpp
@@ -92,18 +92,18 @@ class wayfire_view_shot : public wf::plugin_interface_t
         return false;
     };
 
-    wf::ipc::method_callback on_ipc_capture = [=] (nlohmann::json data)
+    wf::ipc::method_callback on_ipc_capture = [=] (wf::json_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "view-id", number_unsigned);
-        WFJSON_EXPECT_FIELD(data, "file", string);
+        auto view_id = wf::ipc::json_get_uint64(data, "view-id");
+        auto file = wf::ipc::json_get_string(data, "file");
 
-        auto view = wf::ipc::find_view_by_id(data["view-id"]);
+        auto view = wf::ipc::find_view_by_id(view_id);
         if (!view)
         {
             return wf::ipc::json_error("No such view found!");
         }
 
-        if (take_snapshot(view, data["file"]))
+        if (take_snapshot(view, file))
         {
             return wf::ipc::json_ok();
         }

--- a/src/view-shot.cpp
+++ b/src/view-shot.cpp
@@ -95,7 +95,7 @@ class wayfire_view_shot : public wf::plugin_interface_t
     wf::ipc::method_callback on_ipc_capture = [=] (wf::json_t data)
     {
         auto view_id = wf::ipc::json_get_uint64(data, "view-id");
-        auto file = wf::ipc::json_get_string(data, "file");
+        auto file    = wf::ipc::json_get_string(data, "file");
 
         auto view = wf::ipc::find_view_by_id(view_id);
         if (!view)


### PR DESCRIPTION
This should update the plugins relying on json to match the switch to yyjson from the wayfire master branch. I also have changes for the filters submodule locally, but I can't figure out how to include them.
I called the variables for the optionals maybe_x and maybe_y, but maybe there's a nicer way to fix this.