### PR TITLE
Add option 'names' to workspace-names

### DIFF
--- a/metadata/workspace-names.xml
+++ b/metadata/workspace-names.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <wayfire>
 	<plugin name="workspace-names">
 		<_short>Workspace Names</_short>
@@ -82,6 +82,14 @@
 			<_long>Radius for the corners of the background.</_long>
 			<default>30</default>
 			<min>0</min>
+		</option>
+		<option name="names" type="dynamic-list" type-hint="dict">
+			<_short>WorkSpace names</_short>
+			<_long>names of the workspaces. By default, they will have the name Workspace #N, where #N is the workspace number</_long>
+			<entry prefix="" type="string">
+				<_short>Workspace Name</_short>
+				<_long>Sets the name of the workspace</_long>
+			</entry>
 		</option>
 	</plugin>
 </wayfire>

--- a/metadata/workspace-names.xml
+++ b/metadata/workspace-names.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0"?>
 <wayfire>
 	<plugin name="workspace-names">
 		<_short>Workspace Names</_short>
@@ -84,8 +84,8 @@
 			<min>0</min>
 		</option>
 		<option name="names" type="dynamic-list" type-hint="dict">
-			<_short>WorkSpace names</_short>
-			<_long>names of the workspaces. By default, they will have the name Workspace #N, where #N is the workspace number</_long>
+			<_short>Workspace Names</_short>
+			<_long>Names of the workspaces. By default, they will have the name Workspace #N, where #N is the workspace number.</_long>
 			<entry prefix="" type="string">
 				<_short>Workspace Name</_short>
 				<_long>Sets the name of the workspace</_long>

--- a/src/workspace-names.cpp
+++ b/src/workspace-names.cpp
@@ -208,6 +208,7 @@ class wayfire_workspace_names_output : public wf::per_output_plugin_instance_t
         "workspace-names/background_color"};
     wf::option_wrapper_t<bool> show_option_names{"workspace-names/show_option_names"};
     wf::animation::simple_animation_t alpha_fade{display_duration};
+    wf::option_wrapper_t<wf::config::compound_list_t<std::string>> workspace_names{"workspace-names/names"};
 
   public:
     void init() override
@@ -284,25 +285,22 @@ class wayfire_workspace_names_output : public wf::per_output_plugin_instance_t
         auto wsn     = workspaces[x][y]->workspace;
         int ws_num   = x + y * wsize.width + 1;
 
+        // Get intended name of the workspace
+        std::string tmp_name = output->to_string() + "_workspace_" + std::to_string(ws_num);
+
         if (show_option_names)
         {
-            wsn->name = output->to_string() + "_workspace_" +
-                std::to_string(ws_num);
+            wsn->name = tmp_name;
         } else
         {
             bool option_found = false;
-            for (auto option : section->get_registered_options())
+            for (const auto& [wsid, wsname] : workspace_names.value())
             {
-                int ws;
-                if (sscanf(option->get_name().c_str(),
-                    (output->to_string() + "_workspace_%d").c_str(), &ws) == 1)
+                if (wsid == tmp_name)
                 {
-                    if (ws == ws_num)
-                    {
-                        wsn->name    = option->get_value_str();
-                        option_found = true;
-                        break;
-                    }
+                    wsn->name    = wsname;
+                    option_found = true;
+                    break;
                 }
             }
 

--- a/src/workspace-names.cpp
+++ b/src/workspace-names.cpp
@@ -22,17 +22,6 @@
  * SOFTWARE.
  */
 
-/*
- * To set a workspace name, use the following option format:
- *
- * [workspace-names]
- * HDMI-A-1_workspace_3 = Foo
- *
- * This will show Foo when switching to workspace 3 on HDMI-A-1.
- * Enabling show_option_names will show all possible option names
- * on the respective workspaces and outputs.
- */
-
 #include <map>
 #include <wayfire/bindings.hpp>
 #include <wayfire/geometry.hpp>

--- a/src/workspace-names.cpp
+++ b/src/workspace-names.cpp
@@ -34,6 +34,7 @@
  */
 
 #include <map>
+#include <wayfire/bindings.hpp>
 #include <wayfire/geometry.hpp>
 #include <wayfire/workarea.hpp>
 #include <wayfire/opengl.hpp>
@@ -285,18 +286,18 @@ class wayfire_workspace_names_output : public wf::per_output_plugin_instance_t
         auto wsn     = workspaces[x][y]->workspace;
         int ws_num   = x + y * wsize.width + 1;
 
-        // Get intended name of the workspace
-        std::string tmp_name = output->to_string() + "_workspace_" + std::to_string(ws_num);
+        // Get the option name (key) of the target workspace
+        std::string key = output->to_string() + "_workspace_" + std::to_string(ws_num);
 
         if (show_option_names)
         {
-            wsn->name = tmp_name;
+            wsn->name = key;
         } else
         {
             bool option_found = false;
             for (const auto& [wsid, wsname] : workspace_names.value())
             {
-                if (wsid == tmp_name)
+                if (wsid == key)
                 {
                     wsn->name    = wsname;
                     option_found = true;


### PR DESCRIPTION
Currently, we can set custom names to workspaces. However, there is no corresponding option in the xml metadata file. This PR adds the option "names" of type "dynamic-list" with type-hint "dict". Corresponding changes are made in the workspace-names.cpp file as well.