### PR TITLE
update for new wayfire rendering API

### DIFF
--- a/src/crosshair.cpp
+++ b/src/crosshair.cpp
@@ -87,14 +87,8 @@ class wayfire_crosshair : public wf::per_output_plugin_instance_t
             wf::color_t(line_color).b * alpha,
             alpha};
 
-        OpenGL::render_begin(target_fb);
-        for (auto& b : region)
-        {
-            OpenGL::render_rectangle(wlr_box_from_pixman_box(b), color,
-                target_fb.get_orthographic_projection());
-        }
-
-        OpenGL::render_end();
+        auto pass = output->render->get_current_pass();
+        pass->add_rect(color, target_fb, target_fb.geometry, region);
     };
 
     void fini() override

--- a/src/extra-animations/plugin.cpp
+++ b/src/extra-animations/plugin.cpp
@@ -39,6 +39,12 @@ class wayfire_extra_animations : public wf::plugin_interface_t
   public:
     void init() override
     {
+        if (!wf::get_core().is_gles2())
+        {
+            LOGE("wayfire-extra-animations: not supported on non-gles2 wayfire");
+            return;
+        }
+
         effects_registry->register_effect("blinds", wf::animate::effect_description_t{
             .generator = [] { return std::make_unique<wf::blinds::blinds_animation>(); },
             .default_duration = [=] { return wf::blinds::blinds_duration.value(); },

--- a/src/focus-change.cpp
+++ b/src/focus-change.cpp
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <iterator>
 #include <wayfire/bindings.hpp>
 #include <wayfire/config/option.hpp>
 #include <wayfire/core.hpp>

--- a/src/focus-steal-prevent.cpp
+++ b/src/focus-steal-prevent.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <wayfire/per-output-plugin.hpp>
+#include <wayfire/util.hpp>
 #include <wayfire/view-helpers.hpp>
 #include <wayfire/matcher.hpp>
 #include <wayfire/option-wrapper.hpp>

--- a/src/force-fullscreen.cpp
+++ b/src/force-fullscreen.cpp
@@ -77,7 +77,7 @@ class simple_node_render_instance_t : public render_instance_t
 
     void schedule_instructions(
         std::vector<render_instruction_t>& instructions,
-        const wf::render_target_t& target, wf::region_t& damage)
+        const wf::render_target_t& target, wf::region_t& damage) override
     {
         // We want to render ourselves only, the node does not have children
         instructions.push_back(render_instruction_t{
@@ -87,8 +87,7 @@ class simple_node_render_instance_t : public render_instance_t
                     });
     }
 
-    void render(const wf::render_target_t& target,
-        const wf::region_t& region)
+    void render(const wf::scene::render_instruction_t& data) override
     {
         auto output = view->get_output();
 
@@ -97,7 +96,7 @@ class simple_node_render_instance_t : public render_instance_t
             return;
         }
 
-        wf::region_t scissor_region{region};
+        wf::region_t scissor_region{data.damage};
         if (transparent_behind_views)
         {
             auto bbox = *transparent_box;
@@ -108,14 +107,7 @@ class simple_node_render_instance_t : public render_instance_t
             scissor_region ^= wf::region_t{bbox};
         }
 
-        OpenGL::render_begin(target);
-        for (auto& box : scissor_region)
-        {
-            target.logic_scissor(wlr_box_from_pixman_box(box));
-            OpenGL::clear({0, 0, 0, 1});
-        }
-
-        OpenGL::render_end();
+        data.pass->clear(scissor_region, {0, 0, 0, 1});
     }
 };
 

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -26,6 +26,7 @@
 #include <wayfire/plugin.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/signal-definitions.hpp>
+#include <wayfire/util.hpp>
 
 namespace wf_hide_cursor
 {

--- a/src/mag.cpp
+++ b/src/mag.cpp
@@ -25,14 +25,13 @@
 #include "wayfire/txn/transaction-manager.hpp"
 #include "wayfire/core.hpp"
 #include "wayfire/toplevel-view.hpp"
-#include "wayfire/workspace-set.hpp"
 #include "wayfire/plugin.hpp"
+#include <wayfire/workspace-set.hpp>
 #include <wayfire/geometry.hpp>
 #include <wayfire/scene-operations.hpp>
 #include "wayfire/output.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include "wayfire/output-layout.hpp"
-#include "wayfire/compositor-view.hpp"
 #include "wayfire/render-manager.hpp"
 #include "wayfire/opengl.hpp"
 #include "wayfire/per-output-plugin.hpp"
@@ -59,7 +58,7 @@ class mag_view_t : public wf::toplevel_view_interface_t
         {
           public:
             using simple_render_instance_t::simple_render_instance_t;
-            void render(const wf::render_target_t& target, const wf::region_t& region) override
+            void render(const wf::scene::render_instruction_t& data) override
             {
                 auto view = self->_view.lock();
                 if (!view)
@@ -68,19 +67,8 @@ class mag_view_t : public wf::toplevel_view_interface_t
                 }
 
                 auto geometry = self->get_bounding_box();
-                gl_geometry src_geometry = {(float)geometry.x, (float)geometry.y,
-                    (float)geometry.x + geometry.width, (float)geometry.y + geometry.height};
-
-                OpenGL::render_begin(target);
-                for (const auto& box : region)
-                {
-                    target.logic_scissor(wlr_box_from_pixman_box(box));
-                    /* Draw the inside of the rect */
-                    OpenGL::render_transformed_texture(wf::texture_t{view->mag_tex.tex}, src_geometry, {},
-                        target.get_orthographic_projection(), glm::vec4(1.0), 0);
-                }
-
-                OpenGL::render_end();
+                /* Draw the inside of the rect */
+                data.pass->add_texture({view->mag_tex.get_texture()}, data.target, geometry, data.damage);
             }
         };
 
@@ -174,18 +162,11 @@ class mag_view_t : public wf::toplevel_view_interface_t
     bool _is_mapped = false;
 
   public:
-    wf::framebuffer_t mag_tex;
+    wf::auxilliary_buffer_t mag_tex;
 
     mag_view_t() : wf::toplevel_view_interface_t()
     {
         this->role = wf::VIEW_ROLE_TOPLEVEL;
-    }
-
-    ~mag_view_t()
-    {
-        OpenGL::render_begin();
-        mag_tex.release();
-        OpenGL::render_end();
     }
 
     static std::shared_ptr<mag_view_t> create(wf::output_t *output)
@@ -281,6 +262,12 @@ class wayfire_magnifier : public wf::per_output_plugin_instance_t
   public:
     void init() override
     {
+        if (!wf::get_core().is_gles2())
+        {
+            LOGE("mag plugin requires GLES2 renderer!");
+            return;
+        }
+
         output->add_activator(toggle_binding, &toggle_cb);
         hook_set = active = false;
     }
@@ -340,9 +327,8 @@ class wayfire_magnifier : public wf::per_output_plugin_instance_t
     wf::effect_hook_t post_hook = [=] ()
     {
         auto cursor_position = output->get_cursor_position();
-
-        auto ortho = output->render->get_target_framebuffer()
-            .get_orthographic_projection();
+        auto ortho =
+            wf::gles::render_target_orthographic_projection(output->render->get_target_framebuffer());
 
         // Map from OpenGL coordinates to [0, 1]x[0, 1]
         auto cursor_transform =
@@ -411,16 +397,25 @@ class wayfire_magnifier : public wf::per_output_plugin_instance_t
 
         /* Copy zoom_box part of the output to our own texture to be
          * read by the mag_view_t. */
+        if (mag_view->mag_tex.allocate(wf::dimensions(og)) == wf::buffer_reallocation_result_t::REALLOCATED)
+        {
+            // Clear the buffer if reallocated
+            wf::gles::run_in_context([&]
+            {
+                wf::gles::bind_render_buffer(mag_view->mag_tex.get_renderbuffer());
+                OpenGL::clear({0, 0, 0, 0});
+            });
+        }
 
-        OpenGL::render_begin();
-        mag_view->mag_tex.allocate(width, height);
-        mag_view->mag_tex.bind();
-        GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER,
-            output->render->get_target_framebuffer().fb));
-        GL_CALL(glBlitFramebuffer(zoom_box.x1, zoom_box.y2, zoom_box.x2, zoom_box.y1,
-            0, 0, width, height,
-            GL_COLOR_BUFFER_BIT, GL_LINEAR));
-        OpenGL::render_end();
+        wf::gles::run_in_context([&]
+        {
+            auto src_fb_id = wf::gles::ensure_render_buffer_fb_id(output->render->get_target_framebuffer());
+            wf::gles::bind_render_buffer(mag_view->mag_tex.get_renderbuffer());
+            GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER, src_fb_id));
+            GL_CALL(glBlitFramebuffer(zoom_box.x1, zoom_box.y2, zoom_box.x2, zoom_box.y1,
+                0, 0, width, height,
+                GL_COLOR_BUFFER_BIT, GL_LINEAR));
+        });
 
         mag_view->damage();
     };

--- a/src/showrepaint.cpp
+++ b/src/showrepaint.cpp
@@ -40,11 +40,17 @@ class wayfire_showrepaint : public wf::per_output_plugin_instance_t
     wf::option_wrapper_t<wf::activatorbinding_t> toggle_binding{"showrepaint/toggle"};
     wf::option_wrapper_t<bool> reduce_flicker{"showrepaint/reduce_flicker"};
     bool active, egl_swap_buffers_with_damage;
-    wf::framebuffer_t last_buffer;
+    wf::auxilliary_buffer_t last_buffer;
 
   public:
     void init() override
     {
+        if (!wf::get_core().is_gles2())
+        {
+            LOGE("showrepaint plugin requires GLES2 renderer!");
+            return;
+        }
+
         active = false;
         egl_swap_buffers_with_damage =
             egl_extension_supported("EGL_KHR_swap_buffers_with_damage") ||
@@ -77,14 +83,14 @@ class wayfire_showrepaint : public wf::per_output_plugin_instance_t
 
     bool egl_extension_supported(std::string ext)
     {
-        OpenGL::render_begin();
-        EGLDisplay egl_display = eglGetCurrentDisplay();
-        std::string extensions =
-            std::string(eglQueryString(egl_display, EGL_EXTENSIONS));
-        OpenGL::render_end();
+        std::string extensions;
+        wf::gles::run_in_context([&]
+        {
+            EGLDisplay egl_display = eglGetCurrentDisplay();
+            extensions = std::string(eglQueryString(egl_display, EGL_EXTENSIONS));
+        });
 
         size_t pos = extensions.find(ext);
-
         if (pos == std::string::npos)
         {
             return false;
@@ -109,7 +115,7 @@ class wayfire_showrepaint : public wf::per_output_plugin_instance_t
         auto target_fb = output->render->get_target_framebuffer();
         wf::region_t swap_damage = output->render->get_swap_damage();
         wf::region_t scheduled_damage = output->render->get_scheduled_damage();
-        wlr_box fbg = {0, 0, target_fb.viewport_width, target_fb.viewport_height};
+        wlr_box fbg = {0, 0, target_fb.get_size().width, target_fb.get_size().height};
         wf::region_t output_region{fbg};
         wf::region_t inverted_damage;
         wf::region_t damage;
@@ -125,99 +131,94 @@ class wayfire_showrepaint : public wf::per_output_plugin_instance_t
         get_random_color(color);
         damage = scheduled_damage.empty() ? swap_damage : scheduled_damage;
 
-        OpenGL::render_begin(target_fb);
-        for (const auto& b : damage)
-        {
-            wlr_box box{b.x1, b.y1, b.x2 - b.x1, b.y2 - b.y1};
-            OpenGL::render_rectangle(box, color,
-                target_fb.get_orthographic_projection());
-        }
+        last_buffer.allocate({fbg.width, fbg.height});
+        GLuint last_buffer_fb_id = wf::gles::ensure_render_buffer_fb_id(last_buffer.get_renderbuffer());
+        GLuint target_fb_fb_id   = wf::gles::ensure_render_buffer_fb_id(target_fb);
 
-        if (reduce_flicker)
+        output->render->get_current_pass()->custom_gles_subpass([&]
         {
-            /* Show swap damage. It might be possible that we blit right over this
-             * but in the case of cube and expo, it shows client and swap damage in
-             * contrast. This makes sense since the idea is to show damage as colored
-             * regions. We don't do this if the reduce_flicker option isn't set
-             * because
-             * we don't repaint the inverted damage from the last buffer in this
-             * case,
-             * so we would keep painting it with different colors until it is white.
-             * */
-            get_random_color(color);
-            inverted_damage = output_region ^ damage;
-            for (const auto& b : inverted_damage)
+            wf::gles::bind_render_buffer(target_fb);
+            for (const auto& b : damage)
             {
                 wlr_box box{b.x1, b.y1, b.x2 - b.x1, b.y2 - b.y1};
                 OpenGL::render_rectangle(box, color,
-                    target_fb.get_orthographic_projection());
+                    wf::gles::render_target_orthographic_projection(target_fb));
             }
-        }
 
-        OpenGL::render_end();
+            if (reduce_flicker)
+            {
+                /* Show swap damage. It might be possible that we blit right over this
+                 * but in the case of cube and expo, it shows client and swap damage in
+                 * contrast. This makes sense since the idea is to show damage as colored
+                 * regions. We don't do this if the reduce_flicker option isn't set
+                 * because
+                 * we don't repaint the inverted damage from the last buffer in this
+                 * case,
+                 * so we would keep painting it with different colors until it is white.
+                 * */
+                get_random_color(color);
+                inverted_damage = output_region ^ damage;
+                for (const auto& b : inverted_damage)
+                {
+                    wlr_box box{b.x1, b.y1, b.x2 - b.x1, b.y2 - b.y1};
+                    OpenGL::render_rectangle(box, color,
+                        wf::gles::render_target_orthographic_projection(target_fb));
+                }
+            }
 
-        /* If swap_buffers_with_damage is supported, we do not need the
-         * following to be executed. */
-        if (egl_swap_buffers_with_damage)
-        {
-            return;
-        }
+            /* If swap_buffers_with_damage is supported, we do not need the
+             * following to be executed. */
+            if (egl_swap_buffers_with_damage)
+            {
+                return;
+            }
 
-        /* User option. */
-        if (!reduce_flicker)
-        {
-            return;
-        }
+            /* User option. */
+            if (!reduce_flicker)
+            {
+                return;
+            }
 
-        fbg.width  = target_fb.viewport_width;
-        fbg.height = target_fb.viewport_height;
+            /* Repaint the inverted damage region with the last buffer contents.
+             * We only want to see what actually changed on screen. If we don't
+             * do this, things like mouse and keyboard input cause buffer swaps
+             * which only make the screen flicker between buffers, without showing
+             * any actual damage changes. If swap_buffers_with_damage is supported,
+             * we do not need to do this since the damage region that is passed to
+             * swap is only repainted. If it isn't supported, the entire buffer is
+             * repainted.
+             */
+            GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER, last_buffer_fb_id));
+            GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, target_fb_fb_id));
+            damage = swap_damage.empty() ? scheduled_damage : swap_damage;
+            output_region   *= target_fb.scale;
+            inverted_damage  = output_region ^ damage;
+            inverted_damage *= 1.0 / target_fb.scale;
+            for (const auto& rect : inverted_damage)
+            {
+                pixman_box32_t b = pixman_box_from_wlr_box(
+                    target_fb.framebuffer_box_from_geometry_box(
+                        wlr_box_from_pixman_box(rect)));
+                GL_CALL(glBlitFramebuffer(
+                    b.x1, fbg.height - b.y2,
+                    b.x2, fbg.height - b.y1,
+                    b.x1, fbg.height - b.y2,
+                    b.x2, fbg.height - b.y1,
+                    GL_COLOR_BUFFER_BIT, GL_LINEAR));
+            }
 
-        OpenGL::render_begin();
-        last_buffer.allocate(fbg.width, fbg.height);
-        OpenGL::render_end();
-
-        /* Repaint the inverted damage region with the last buffer contents.
-         * We only want to see what actually changed on screen. If we don't
-         * do this, things like mouse and keyboard input cause buffer swaps
-         * which only make the screen flicker between buffers, without showing
-         * any actual damage changes. If swap_buffers_with_damage is supported,
-         * we do not need to do this since the damage region that is passed to
-         * swap is only repainted. If it isn't supported, the entire buffer is
-         * repainted.
-         */
-        OpenGL::render_begin(target_fb);
-        GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER, last_buffer.fb));
-        damage = swap_damage.empty() ? scheduled_damage : swap_damage;
-        output_region   *= target_fb.scale;
-        inverted_damage  = output_region ^ damage;
-        inverted_damage *= 1.0 / target_fb.scale;
-        for (const auto& rect : inverted_damage)
-        {
-            pixman_box32_t b = pixman_box_from_wlr_box(
-                target_fb.framebuffer_box_from_geometry_box(
-                    wlr_box_from_pixman_box(rect)));
+            /* Save the current buffer to last buffer so we can render the
+             * inverted damage from the last buffer to the current buffer
+             * on next frame. We have to save the entire buffer because we
+             * don't know what the next frame damage will be.
+             */
+            GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER, target_fb_fb_id));
+            GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, last_buffer_fb_id));
             GL_CALL(glBlitFramebuffer(
-                b.x1, fbg.height - b.y2,
-                b.x2, fbg.height - b.y1,
-                b.x1, fbg.height - b.y2,
-                b.x2, fbg.height - b.y1,
+                0, 0, fbg.width, fbg.height,
+                0, 0, fbg.width, fbg.height,
                 GL_COLOR_BUFFER_BIT, GL_LINEAR));
-        }
-
-        OpenGL::render_end();
-
-        /* Save the current buffer to last buffer so we can render the
-         * inverted damage from the last buffer to the current buffer
-         * on next frame. We have to save the entire buffer because we
-         * don't know what the next frame damage will be.
-         */
-        OpenGL::render_begin(last_buffer);
-        GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER, target_fb.fb));
-        GL_CALL(glBlitFramebuffer(
-            0, 0, fbg.width, fbg.height,
-            0, 0, fbg.width, fbg.height,
-            GL_COLOR_BUFFER_BIT, GL_LINEAR));
-        OpenGL::render_end();
+        });
     };
 
     void fini() override

--- a/src/showrepaint.cpp
+++ b/src/showrepaint.cpp
@@ -140,8 +140,7 @@ class wayfire_showrepaint : public wf::per_output_plugin_instance_t
             wf::gles::bind_render_buffer(target_fb);
             for (const auto& b : damage)
             {
-                wlr_box box{b.x1, b.y1, b.x2 - b.x1, b.y2 - b.y1};
-                OpenGL::render_rectangle(box, color,
+                OpenGL::render_rectangle(wlr_box_from_pixman_box(b), color,
                     wf::gles::render_target_orthographic_projection(target_fb));
             }
 
@@ -160,8 +159,7 @@ class wayfire_showrepaint : public wf::per_output_plugin_instance_t
                 inverted_damage = output_region ^ damage;
                 for (const auto& b : inverted_damage)
                 {
-                    wlr_box box{b.x1, b.y1, b.x2 - b.x1, b.y2 - b.y1};
-                    OpenGL::render_rectangle(box, color,
+                    OpenGL::render_rectangle(wlr_box_from_pixman_box(b), color,
                         wf::gles::render_target_orthographic_projection(target_fb));
                 }
             }
@@ -200,10 +198,10 @@ class wayfire_showrepaint : public wf::per_output_plugin_instance_t
                     target_fb.framebuffer_box_from_geometry_box(
                         wlr_box_from_pixman_box(rect)));
                 GL_CALL(glBlitFramebuffer(
-                    b.x1, fbg.height - b.y2,
-                    b.x2, fbg.height - b.y1,
-                    b.x1, fbg.height - b.y2,
-                    b.x2, fbg.height - b.y1,
+                    b.x1, b.y1,
+                    b.x2, b.y2,
+                    b.x1, b.y1,
+                    b.x2, b.y2,
                     GL_COLOR_BUFFER_BIT, GL_LINEAR));
             }
 

--- a/src/view-shot.cpp
+++ b/src/view-shot.cpp
@@ -113,27 +113,9 @@ class wayfire_view_shot : public wf::plugin_interface_t
 
     bool take_snapshot(wayfire_view view, std::string filename)
     {
-        wf::render_target_t offscreen_buffer;
-        view->take_snapshot(offscreen_buffer);
-        auto width  = offscreen_buffer.viewport_width;
-        auto height = offscreen_buffer.viewport_height;
-
-        GLubyte *pixels = (GLubyte*)malloc(width * height * sizeof(GLubyte) * 4);
-        if (!pixels)
-        {
-            return false;
-        }
-
-        OpenGL::render_begin();
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, offscreen_buffer.fb));
-        GL_CALL(glViewport(0, 0, width, height));
-
-        GL_CALL(glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
-        offscreen_buffer.release(); // free gpu memory
-        OpenGL::render_end();
-
-        image_io::write_to_file(filename, pixels, width, height, "png", true);
-        free(pixels);
+        wf::auxilliary_buffer_t aux_buffer;
+        view->take_snapshot(aux_buffer);
+        image_io::write_to_file(filename, aux_buffer.get_renderbuffer());
         return true;
     }
 

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -325,7 +325,6 @@ class wayfire_water_screen : public wf::per_output_plugin_instance_t, public wf:
             glm::vec4 result = transform * point;
             x = (result.x + center.x) * fbg.width;
             y = (result.y + center.y) * fbg.height;
-            y = fbg.height - y;
             points.push_back(x);
             points.push_back(y);
         }
@@ -347,10 +346,10 @@ class wayfire_water_screen : public wf::per_output_plugin_instance_t, public wf:
         }
 
         wf::gles_texture_t tex[2] = {
-            wf::gles_texture_t{buffer[0].get_texture()},
-            wf::gles_texture_t{buffer[1].get_texture()},
+            wf::gles_texture_t::from_aux(buffer[0]),
+            wf::gles_texture_t::from_aux(buffer[1]),
         };
-        wf::gles_texture_t source_tex{source.get_texture()};
+        wf::gles_texture_t source_tex = wf::gles_texture_t::from_aux(source);
 
         wf::gles::run_in_context([&]
         {

--- a/src/window-zoom.cpp
+++ b/src/window-zoom.cpp
@@ -119,25 +119,12 @@ class simple_node_render_instance_t : public transformer_render_instance_t<trans
         return *transformed_view_geometry;
     }
 
-    void render(const wf::render_target_t& target,
-        const wf::region_t& region) override
+    void render(const wf::scene::render_instruction_t& data) override
     {
-        auto src_tex = transformer_render_instance_t<transformer_base_node_t>::get_texture(1.0);
-
-        OpenGL::render_begin(target);
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, src_tex.tex_id));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
-            nearest_filtering ? GL_NEAREST : GL_LINEAR));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-            nearest_filtering ? GL_NEAREST : GL_LINEAR));
+        auto src_tex = get_texture(1.0);
         auto scaled_geometry = get_scaled_geometry();
-        for (const auto& box : region)
-        {
-            target.logic_scissor(wlr_box_from_pixman_box(box));
-            OpenGL::render_texture(src_tex, target, scaled_geometry, glm::vec4(1.0));
-        }
-
-        OpenGL::render_end();
+        src_tex.filter_mode = nearest_filtering ? WLR_SCALE_FILTER_NEAREST : WLR_SCALE_FILTER_BILINEAR;
+        data.pass->add_texture(src_tex, data.target, scaled_geometry, data.damage);
     }
 };
 


### PR DESCRIPTION
https://github.com/WayfireWM/wayfire/pull/2613 introduced some changes to Wayfire's rendering API. Some plugins I ported to use render-agnostic APIs, where it was harder (or impossible) I left custom GL rendering.

Note: I have not tested all of the plugins, only a couple of them (annotate, showrepaint, crosshair, bench). I thought it would be a good first step to get the code compiling and then let users test and report issues found, as I have not used many of those plugins and am not looking forward to testing all of them :)

P.S. the PR seems massive with many lines changed, but actually most of the lines are changes in the indentation due to the replacement of `OpenGL::render_begin/end`.
