### PR TITLE
plugins: s/mediump/highp/

### DIFF
--- a/src/extra-animations/blinds.hpp
+++ b/src/extra-animations/blinds.hpp
@@ -43,8 +43,8 @@ static const char *blinds_vert_source =
     R"(
 #version 100
 
-attribute mediump vec3 position;
-attribute mediump vec2 uv_in;
+attribute highp vec3 position;
+attribute highp vec2 uv_in;
 
 uniform mat4 matrix;
 
@@ -62,7 +62,7 @@ static const char *blinds_frag_source =
 @builtin_ext@
 @builtin@
 
-precision mediump float;
+precision highp float;
 
 varying highp vec2 uv;
 

--- a/src/extra-animations/helix.hpp
+++ b/src/extra-animations/helix.hpp
@@ -43,8 +43,8 @@ static const char *helix_vert_source =
     R"(
 #version 100
 
-attribute mediump vec3 position;
-attribute mediump vec2 uv_in;
+attribute highp vec3 position;
+attribute highp vec2 uv_in;
 
 uniform mat4 matrix;
 
@@ -62,7 +62,7 @@ static const char *helix_frag_source =
 @builtin_ext@
 @builtin@
 
-precision mediump float;
+precision highp float;
 
 varying highp vec2 uv;
 

--- a/src/extra-animations/shatter.hpp
+++ b/src/extra-animations/shatter.hpp
@@ -48,8 +48,8 @@ static const char *shatter_vert_source =
     R"(
 #version 100
 
-attribute mediump vec2 position;
-attribute mediump vec2 uv_in;
+attribute highp vec2 position;
+attribute highp vec2 uv_in;
 
 uniform mat4 matrix;
 
@@ -67,10 +67,10 @@ static const char *shatter_frag_source =
 @builtin_ext@
 @builtin@
 
-precision mediump float;
+precision highp float;
 
 varying highp vec2 uv;
-uniform mediump float alpha;
+uniform highp float alpha;
 
 void main()
 {

--- a/src/extra-animations/vortex.hpp
+++ b/src/extra-animations/vortex.hpp
@@ -43,8 +43,8 @@ static const char *vortex_vert_source =
     R"(
 #version 100
 
-attribute mediump vec2 position;
-attribute mediump vec2 uv_in;
+attribute highp vec2 position;
+attribute highp vec2 uv_in;
 
 uniform mat4 matrix;
 
@@ -62,10 +62,10 @@ static const char *vortex_frag_source =
 @builtin_ext@
 @builtin@
 
-precision mediump float;
+precision highp float;
 
 varying highp vec2 uv;
-uniform mediump float progress;
+uniform highp float progress;
 
 const float PI = 3.1415926535897932384626433832795;
 

--- a/src/keycolor.cpp
+++ b/src/keycolor.cpp
@@ -36,10 +36,10 @@ static const char *vertex_shader =
     R"(
 #version 100
 
-attribute mediump vec2 position;
-attribute mediump vec2 texcoord;
+attribute highp vec2 position;
+attribute highp vec2 texcoord;
 
-varying mediump vec2 uvpos;
+varying highp vec2 uvpos;
 
 uniform mat4 mvp;
 
@@ -56,12 +56,12 @@ static const char *fragment_shader =
 @builtin_ext@
 @builtin@
 
-precision mediump float;
+precision highp float;
 
-uniform mediump vec4 color;
+uniform highp vec4 color;
 uniform float threshold;
 
-varying mediump vec2 uvpos;
+varying highp vec2 uvpos;
 
 void main()
 {

--- a/src/obs.cpp
+++ b/src/obs.cpp
@@ -41,10 +41,10 @@ static const char *vertex_shader =
     R"(
 #version 100
 
-attribute mediump vec2 position;
-attribute mediump vec2 texcoord;
+attribute highp vec2 position;
+attribute highp vec2 texcoord;
 
-varying mediump vec2 uvpos;
+varying highp vec2 uvpos;
 
 uniform mat4 mvp;
 
@@ -61,14 +61,14 @@ static const char *fragment_shader =
 @builtin_ext@
 @builtin@
 
-precision mediump float;
+precision highp float;
 
 /* Input uniforms are 0-1 range. */
-uniform mediump float opacity;
-uniform mediump float brightness;
-uniform mediump float saturation;
+uniform highp float opacity;
+uniform highp float brightness;
+uniform highp float saturation;
 
-varying mediump vec2 uvpos;
+varying highp vec2 uvpos;
 
 vec3 saturate(vec3 rgb, float adjustment)
 {

--- a/src/showtouch.cpp
+++ b/src/showtouch.cpp
@@ -40,10 +40,10 @@ static const char *vertex_shader =
     R"(
 #version 300 es
 
-in mediump vec2 position;
-in mediump vec2 texcoord;
+in highp vec2 position;
+in highp vec2 texcoord;
 
-out mediump vec2 uvpos;
+out highp vec2 uvpos;
 
 void main() {
 
@@ -58,10 +58,10 @@ static const char *fragment_shader =
 @builtin_ext@
 @builtin@
 
-precision mediump float;
+precision highp float;
 
 out vec4 out_color;
-in mediump vec2 uvpos;
+in highp vec2 uvpos;
 uniform vec2 resolution;
 uniform vec2 finger0;
 uniform vec2 finger1;

--- a/src/water.cpp
+++ b/src/water.cpp
@@ -39,7 +39,7 @@ static const char *vertex_shader =
     R"(
 #version 100
 
-attribute mediump vec2 position;
+attribute highp vec2 position;
 attribute highp vec2 uvPosition;
 
 varying highp vec2 uvpos;
@@ -54,7 +54,7 @@ void main()
 static const char *fragment_shader_a =
     R"(
 #version 100
-precision mediump float;
+precision highp float;
 
 uniform int num_points;
 uniform vec2 points[64];
@@ -65,11 +65,10 @@ uniform sampler2D u_texture;
 void main()
 {
     int i;
-    for (i = 0; i < num_points; i++)
+    for (i = 0; button_down == 1 && i < num_points; i++)
     {
-        vec2 r = gl_FragCoord.xy - points[i];
-        float d = 0.005 * dot(r, r);
-        if (button_down == 1 && d < 0.05)
+        float d = length(gl_FragCoord.xy - points[i]);
+        if (d < 3.)
         {
             gl_FragColor = vec4(0.0, 1.0, 0.0, 0.0);
             return;
@@ -83,7 +82,7 @@ void main()
 static const char *fragment_shader_b =
     R"(
 #version 100
-precision mediump float;
+precision highp float;
 
 uniform vec2 resolution;
 varying highp vec2 uvpos;
@@ -125,7 +124,7 @@ void main()
 static const char *fragment_shader_c =
     R"(
 #version 100
-precision mediump float;
+precision highp float;
 
 #define DEBUG 0
 


### PR DESCRIPTION
This fixes various rendering oddities, such as unintentional wind in water and tearing in vortex animation.