### PR TITLE
annotate: fix unloading

### DIFF
--- a/src/annotate.cpp
+++ b/src/annotate.cpp
@@ -775,19 +775,13 @@ class wayfire_annotate_screen : public wf::per_output_plugin_instance_t, public 
         ungrab();
         output->rem_binding(&draw_begin);
         output->rem_binding(&clear_workspace);
-        auto wsize = output->wset()->get_workspace_grid_size();
-        for (int x = 0; x < wsize.width; x++)
+        for (auto& row: overlays)
         {
-            for (int y = 0; y < wsize.height; y++)
+            for (auto& overlay : row)
             {
-                auto& ol = overlays[x][y]->overlay;
-                overlay_destroy(ol);
-                ol.reset();
-                auto& shape_overlay = overlays[x][y]->shape_overlay;
-                overlay_destroy(shape_overlay);
-                shape_overlay.reset();
-                wf::scene::remove_child(overlays[x][y]);
-                overlays[x][y].reset();
+                overlay_destroy(overlay->overlay);
+                overlay_destroy(overlay->shape_overlay);
+                wf::scene::remove_child(overlay);
             }
         }
 


### PR DESCRIPTION
When annotate is loaded on non-GLES renderer, it will not initialize the
overlay array. So when we iterate at the end, it will crash as the array
is empty. Instead, we can iterate over all the elements in the array.
This way, it works also for empty arrays :)

In addition I also removed a few of the .reset() calls. They are not
necessary, as the memory will be freed automatically by the smart
pointers (shared_ptrs, unique_ptrs).
