### PR TITLE
build: Don't depend on json directly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,6 @@ giomm = dependency('giomm-2.4', required: false)
 wayland_protos = dependency('wayland-protocols', version: '>=1.12')
 wayland_server = dependency('wayland-server')
 evdev = dependency('libevdev')
-json = dependency('yyjson', required: false)
 
 if get_option('enable_wayfire_shadows') == true
     wayfire_shadows = subproject('wayfire-shadows')

--- a/src/meson.build
+++ b/src/meson.build
@@ -58,14 +58,13 @@ magnifier = shared_module('mag', 'mag.cpp',
     dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
 
-if json.found()
 obs = shared_module('obs', 'obs.cpp',
-    dependencies: [wayfire, json],
+    dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
 pin_view = shared_module('pin-view', 'pin-view.cpp',
-    dependencies: [wayfire, json],
+    dependencies: [wayfire],
     install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))
-endif
 
 showrepaint = shared_module('showrepaint', 'showrepaint.cpp',
     dependencies: [wayfire],


### PR DESCRIPTION
Depending on wayfire is enough, since the plugin API abstracts the underlying json library implementation.

Fixes #276.