### PR TITLE
Add workspace-names setter script and update plugin to allow usage

### DIFF
--- a/ipc-scripts/workspace-names-setter.py
+++ b/ipc-scripts/workspace-names-setter.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+from wayfire import WayfireSocket
+import json
+import sys
+
+# Simple script to set workspace names
+
+if len(sys.argv) != 2:
+    print("Invalid usage, exactly one argument required: a workspace name for the current output and workspace.")
+    print(len(sys.argv))
+    exit(-1)
+
+sock = WayfireSocket()
+
+output = sock.get_focused_output()
+output_name = output["name"]
+current_workspace = str(int(output["workspace"]["x"]) + int(output["workspace"]["y"]) * int(output["workspace"]["grid_width"]) + 1)
+json_string = "{\"workspace-names/" + output_name + "_workspace_" + current_workspace + "\": \"" + sys.argv[1] + "\"}"
+sock.set_option_values(json.loads(json_string))

--- a/src/workspace-names.cpp
+++ b/src/workspace-names.cpp
@@ -285,13 +285,33 @@ class wayfire_workspace_names_output : public wf::per_output_plugin_instance_t
         } else
         {
             bool option_found = false;
-            for (const auto& [wsid, wsname] : workspace_names.value())
+            for (auto option : section->get_registered_options())
             {
-                if (wsid == key)
+                int ws;
+                if (sscanf(option->get_name().c_str(), (output->to_string() + "_workspace_%d").c_str(),
+                    &ws) != 1)
                 {
-                    wsn->name    = wsname;
+                    continue;
+                }
+
+                if (ws == ws_num)
+                {
+                    wsn->name    = option->get_value_str();
                     option_found = true;
                     break;
+                }
+            }
+
+            if (!option_found)
+            {
+                for (const auto& [wsid, wsname] : workspace_names.value())
+                {
+                    if (wsid == key)
+                    {
+                        wsn->name    = wsname;
+                        option_found = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
This pull request adds `ipc-scripts/workspace-names-setter.py` which takes a single string argument and sets the workspace name for the currently focused output and workspace. Workspace-names plugin was modified to check registered options and make this work.