### PR TITLE
fix: autorotate-iio: fix D-Bus events not processed when display is idle

### DIFF
--- a/src/autorotate-iio.cpp
+++ b/src/autorotate-iio.cpp
@@ -22,6 +22,7 @@ extern "C"
 {
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_seat.h>
+#include <wayland-server-core.h>
 }
 
 using namespace Gio;
@@ -105,6 +106,12 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
     /* Transform coming from the iio-sensors, -1 means not set */
     int32_t sensor_transform = -1;
 
+    /* Debounce: pending transform waiting to be confirmed stable */
+    int32_t pending_transform = -1;
+    guint debounce_timer_id = 0;
+    static constexpr guint DEBOUNCE_ROTATE_MS = 500;
+    static constexpr guint DEBOUNCE_NORMAL_MS = 1200;
+
     bool on_rotate_binding(int32_t target_rotation)
     {
         if (!output->can_activate_plugin(&grab_interface))
@@ -154,10 +161,18 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
         return true;
     }
 
-    wf::effect_hook_t on_frame = [=] ()
+    /* Wayland event loop timer — fires every 50ms to pump the GLib main context
+     * even when the display is idle and on_frame would not run. */
+    wl_event_source *glib_timer = nullptr;
+
+    static int glib_timer_cb(void *data)
     {
+        auto *self = static_cast<WayfireAutorotateIIO*>(data);
         Glib::MainContext::get_default()->iteration(false);
-    };
+        wl_event_source_timer_update(self->glib_timer, 50);
+        return 0;
+    }
+
     Glib::RefPtr<Glib::MainLoop> loop;
 
   public:
@@ -185,7 +200,10 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
         Gio::init();
 
         loop = Glib::MainLoop::create(true);
-        output->render->add_effect(&on_frame, wf::OUTPUT_EFFECT_PRE);
+
+        auto *evloop = wl_display_get_event_loop(wf::get_core().display);
+        glib_timer = wl_event_loop_add_timer(evloop, glib_timer_cb, this);
+        wl_event_source_timer_update(glib_timer, 50);
 
         watch_id = DBus::watch_name(DBus::BUS_TYPE_SYSTEM, "net.hadess.SensorProxy",
             sigc::mem_fun(this, &WayfireAutorotateIIO::on_iio_appeared),
@@ -210,6 +228,7 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
         iio_proxy->signal_properties_changed().connect_notify(
             sigc::mem_fun(this, &WayfireAutorotateIIO::on_properties_changed));
         iio_proxy->call_sync("ClaimAccelerometer");
+        update_orientation();
     }
 
     void on_properties_changed(
@@ -228,6 +247,11 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
 
         Glib::Variant<Glib::ustring> orientation;
         iio_proxy->get_cached_property(orientation, "AccelerometerOrientation");
+        if (!orientation)
+        {
+            return;
+        }
+
         LOGI("IIO Accelerometer orientation: %s", orientation.get().c_str());
 
         static const std::map<std::string, wl_output_transform> transform_by_name =
@@ -238,10 +262,57 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
             {"bottom-up", WL_OUTPUT_TRANSFORM_180},
         };
 
-        if (transform_by_name.count(orientation.get()))
+        if (!transform_by_name.count(orientation.get()))
         {
-            sensor_transform = transform_by_name.find(orientation.get())->second;
-            update_transform();
+            return;
+        }
+
+        int32_t new_transform = transform_by_name.find(orientation.get())->second;
+
+        bool timer_running  = (debounce_timer_id != 0);
+        bool new_is_normal  = (new_transform == WL_OUTPUT_TRANSFORM_NORMAL);
+        bool pend_is_normal = (pending_transform == WL_OUTPUT_TRANSFORM_NORMAL);
+
+        if (!timer_running)
+        {
+            if (new_transform == sensor_transform)
+            {
+                return;
+            }
+
+            pending_transform = new_transform;
+            guint delay = new_is_normal ? DEBOUNCE_NORMAL_MS : DEBOUNCE_ROTATE_MS;
+            debounce_timer_id = g_timeout_add(delay, [] (gpointer data) -> gboolean
+            {
+                auto *self = static_cast<WayfireAutorotateIIO*>(data);
+                self->debounce_timer_id = 0;
+                self->sensor_transform  = self->pending_transform;
+                self->update_transform();
+                return G_SOURCE_REMOVE;
+            }, this);
+        }
+        else if (!pend_is_normal)
+        {
+            if (!new_is_normal)
+            {
+                pending_transform = new_transform;
+            }
+        }
+        else
+        {
+            if (!new_is_normal)
+            {
+                g_source_remove(debounce_timer_id);
+                pending_transform = new_transform;
+                debounce_timer_id = g_timeout_add(DEBOUNCE_ROTATE_MS, [] (gpointer data) -> gboolean
+                {
+                    auto *self = static_cast<WayfireAutorotateIIO*>(data);
+                    self->debounce_timer_id = 0;
+                    self->sensor_transform  = self->pending_transform;
+                    self->update_transform();
+                    return G_SOURCE_REMOVE;
+                }, this);
+            }
         }
     }
 
@@ -259,13 +330,20 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
         output->rem_binding(&on_rotate_up);
         output->rem_binding(&on_rotate_down);
 
+        if (debounce_timer_id)
+        {
+            g_source_remove(debounce_timer_id);
+            debounce_timer_id = 0;
+        }
+
         /* If loop is NULL, autorotate was disabled for the current output */
         if (loop)
         {
             iio_proxy.reset();
             DBus::unwatch_name(watch_id);
             loop->quit();
-            output->render->rem_effect(&on_frame);
+            wl_event_source_remove(glib_timer);
+            glib_timer = nullptr;
         }
     }
 };

--- a/src/autorotate-iio.cpp
+++ b/src/autorotate-iio.cpp
@@ -108,7 +108,7 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
 
     /* Debounce: pending transform waiting to be confirmed stable */
     int32_t pending_transform = -1;
-    guint debounce_timer_id = 0;
+    guint debounce_timer_id   = 0;
     static constexpr guint DEBOUNCE_ROTATE_MS = 500;
     static constexpr guint DEBOUNCE_NORMAL_MS = 1200;
 
@@ -290,15 +290,13 @@ class WayfireAutorotateIIO : public wf::per_output_plugin_instance_t
                 self->update_transform();
                 return G_SOURCE_REMOVE;
             }, this);
-        }
-        else if (!pend_is_normal)
+        } else if (!pend_is_normal)
         {
             if (!new_is_normal)
             {
                 pending_transform = new_transform;
             }
-        }
-        else
+        } else
         {
             if (!new_is_normal)
             {


### PR DESCRIPTION
Fixes #336.

## Problem

The plugin drove the GLib main context from an `OUTPUT_EFFECT_PRE` hook that only fires while the compositor renders frames. When the display is idle, no frames render, GLib never runs, and `iio-sensor-proxy` property-change signals queue up unprocessed — rotation silently stops working.

## Changes

**Main fix:** Replace `on_frame` / `OUTPUT_EFFECT_PRE` with a `wl_event_loop_add_timer(50ms)` on the Wayland event loop (`wl_display_get_event_loop(wf::get_core().display)`). This pumps the GLib main context at a steady rate regardless of display activity.

**Null-guard on `Glib::Variant`:** `get_cached_property()` may leave the variant uninitialized if the D-Bus proxy cache is not yet populated. Calling `.get()` on it crashes the compositor.

**Call `update_orientation()` after `ClaimAccelerometer`:** Without this the plugin only reacts to orientation *changes* — it never reads the current orientation at startup.

**Asymmetric debounce state machine:** Some accelerometers oscillate between the target orientation and "normal" during a physical rotation, resetting the debounce timer on each reading and delaying rotation by 15–20 seconds. The fix:
- 500ms to commit a non-normal (rotated) orientation
- 1200ms to return to normal (longer, to survive mid-rotation noise)
- Rotation timer is **not** reset on subsequent non-normal readings — delay is measured from the first reading, not the last
- Return-to-normal timer is cancelled and replaced by a rotation timer if a non-normal reading arrives

## Testing

Tested on Lenovo Yoga 9 14IRP8 (Intel Iris Xe, eDP-1 @ 3840×2400 scale 2.4), CachyOS, kernel 7.0.0-1-cachyos, wayfire-git r110, wlroots 0.20, iio-sensor-proxy 3.x.