### PR TITLE
[hide-cursor] add disabled_for option

### DIFF
--- a/metadata/hide-cursor.xml
+++ b/metadata/hide-cursor.xml
@@ -15,5 +15,9 @@
 			<default>2000</default>
 			<min>250</min>
 		</option>
+		<option name="disabled_for" type="view_match">
+			<default></default>
+			<description>Disabled for specified window types</description>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/hide-cursor.xml
+++ b/metadata/hide-cursor.xml
@@ -16,7 +16,7 @@
 			<min>250</min>
 		</option>
 		<option name="disabled_for" type="view_match">
-			<default></default>
+			<default>none</default>
 			<description>Disabled for specified window types</description>
 		</option>
 	</plugin>

--- a/metadata/hide-cursor.xml
+++ b/metadata/hide-cursor.xml
@@ -15,9 +15,9 @@
 			<default>2000</default>
 			<min>250</min>
 		</option>
-		<option name="disabled_for" type="view_match">
+		<option name="disabled_for" type="string">
+			<_short>Disabled for specified window types</_short>
+			<_long>Disables cursor hiding for windows matching the specified criteria.</_long>
 			<default>none</default>
-			<description>Disabled for specified window types</description>
 		</option>
 	</plugin>
-</wayfire>

--- a/metadata/hide-cursor.xml
+++ b/metadata/hide-cursor.xml
@@ -21,3 +21,4 @@
 			<default>none</default>
 		</option>
 	</plugin>
+</wayfire>

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -28,7 +28,6 @@
 #include <wayfire/output.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/util.hpp>
-#include <fstream>
 
 namespace wf_hide_cursor
 {

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -3,115 +3,134 @@
  *
  * Copyright (c) 2023 Scott Moreau
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in the
- * Software without restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
- * Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
- * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
-#include <wayfire/plugins/common/shared-core-data.hpp>
+#include <wayfire/matcher.hpp>
+#include <wayfire/output.hpp>
 #include <wayfire/per-output-plugin.hpp>
 #include <wayfire/plugin.hpp>
-#include <wayfire/output.hpp>
+#include <wayfire/plugins/common/shared-core-data.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/util.hpp>
 
-namespace wf_hide_cursor
-{
+namespace wf_hide_cursor {
+
 bool hidden;
 
-class wayfire_hide_cursor
-{
-    wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
-    wf::wl_timer<false> hide_timer;
+class wayfire_hide_cursor {
+  wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
+  wf::view_matcher_t disabled_for{"hide-cursor/disabled_for"};
+  wf::wl_timer<false> hide_timer;
 
-  public:
-    wayfire_hide_cursor()
-    {
-        hidden = false;
-        setup_hide_timer();
-        wf::get_core().connect(&pointer_motion);
+  void hide() {
+    if (!hidden) {
+      wf::get_core().hide_cursor();
+      hidden = true;
+    }
+  }
+
+  void unhide() {
+    if (hidden) {
+      wf::get_core().unhide_cursor();
+      hidden = false;
+    }
+  }
+
+  void setup_hide_timer() {
+    hide_timer.disconnect();
+
+    hide_timer.set_timeout(hide_delay, [=]() { reevaluate(); });
+  }
+
+public:
+  wayfire_hide_cursor() {
+    hidden = false;
+    setup_hide_timer();
+
+    wf::get_core().connect(&pointer_motion);
+    wf::get_core().connect(&workspace_changed);
+  }
+
+  void reevaluate() {
+    auto view = wf::get_core().get_cursor_focus_view();
+
+    if (view && disabled_for.matches(view)) {
+      unhide();
+      hide_timer.disconnect();
+      return;
     }
 
-    wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
-        [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
-    {
-        setup_hide_timer();
-        if (hidden)
-        {
-            wf::get_core().unhide_cursor();
-            hidden = false;
-        }
-    };
+    hide();
+  }
 
-    void setup_hide_timer()
-    {
-        hide_timer.disconnect();
-        hide_timer.set_timeout(hide_delay, [=] ()
-        {
-            if (!hidden)
-            {
-                wf::get_core().hide_cursor();
-                hidden = true;
+  wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>>
+      pointer_motion =
+          [=](wf::input_event_signal<wlr_pointer_motion_event> *ev) {
+            auto view = wf::get_core().get_cursor_focus_view();
+
+            if (view && disabled_for.matches(view)) {
+              unhide();
+              hide_timer.disconnect();
+              return;
             }
-        });
-    }
 
-    ~wayfire_hide_cursor()
-    {
-        pointer_motion.disconnect();
-        hide_timer.disconnect();
-        if (hidden)
-        {
-            wf::get_core().unhide_cursor();
-        }
-    }
+            unhide();
+            setup_hide_timer();
+          };
+
+  wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
+      [=](wf::workspace_changed_signal *ev) { reevaluate(); };
+
+  ~wayfire_hide_cursor() {
+    pointer_motion.disconnect();
+    workspace_changed.disconnect();
+    hide_timer.disconnect();
+    unhide();
+  }
 };
 
-class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t
-{
-    wf::shared_data::ref_ptr_t<wayfire_hide_cursor> global_idle;
+class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t {
+  wf::shared_data::ref_ptr_t<wayfire_hide_cursor> global_idle;
 
-    wf::activator_callback toggle_cb = [=] (auto)
-    {
-        hidden = !hidden;
+  wf::activator_callback toggle_cb = [=](auto) {
+    hidden = !hidden;
 
-        if (hidden)
-        {
-            wf::get_core().hide_cursor();
-        } else
-        {
-            wf::get_core().unhide_cursor();
-        }
-
-        return true;
-    };
-
-  public:
-    void init() override
-    {
-        output->add_activator(
-            wf::option_wrapper_t<wf::activatorbinding_t>{"hide-cursor/toggle"},
-            &toggle_cb);
+    if (hidden) {
+      wf::get_core().hide_cursor();
+    } else {
+      wf::get_core().unhide_cursor();
     }
 
-    void fini() override
-    {
-        output->rem_binding(&toggle_cb);
-    }
+    return true;
+  };
+
+public:
+  void init() override {
+    output->add_activator(
+        wf::option_wrapper_t<wf::activatorbinding_t>{"hide-cursor/toggle"},
+        &toggle_cb);
+  }
+
+  void fini() override { output->rem_binding(&toggle_cb); }
 };
 
 DECLARE_WAYFIRE_PLUGIN(wf::per_output_plugin_t<wayfire_hide_cursor_plugin>);
-}
+
+} // namespace wf_hide_cursor

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -3,134 +3,160 @@
  *
  * Copyright (c) 2023 Scott Moreau
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #include <wayfire/matcher.hpp>
-#include <wayfire/output.hpp>
+#include <wayfire/plugins/common/shared-core-data.hpp>
 #include <wayfire/per-output-plugin.hpp>
 #include <wayfire/plugin.hpp>
-#include <wayfire/plugins/common/shared-core-data.hpp>
+#include <wayfire/output.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/util.hpp>
 
-namespace wf_hide_cursor {
-
+namespace wf_hide_cursor
+{
 bool hidden;
 
-class wayfire_hide_cursor {
-  wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
-  wf::view_matcher_t disabled_for{"hide-cursor/disabled_for"};
-  wf::wl_timer<false> hide_timer;
+class wayfire_hide_cursor
+{
+    wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
+    wf::view_matcher_t disabled_for{"hide-cursor/disabled_for"};
+    wf::wl_timer<false> hide_timer;
 
-  void hide() {
-    if (!hidden) {
-      wf::get_core().hide_cursor();
-      hidden = true;
-    }
-  }
-
-  void unhide() {
-    if (hidden) {
-      wf::get_core().unhide_cursor();
-      hidden = false;
-    }
-  }
-
-  void setup_hide_timer() {
-    hide_timer.disconnect();
-
-    hide_timer.set_timeout(hide_delay, [=]() { reevaluate(); });
-  }
-
-public:
-  wayfire_hide_cursor() {
-    hidden = false;
-    setup_hide_timer();
-
-    wf::get_core().connect(&pointer_motion);
-    wf::get_core().connect(&workspace_changed);
-  }
-
-  void reevaluate() {
-    auto view = wf::get_core().get_cursor_focus_view();
-
-    if (view && disabled_for.matches(view)) {
-      unhide();
-      hide_timer.disconnect();
-      return;
+  public:
+    wayfire_hide_cursor()
+    {
+        hidden = false;
+        setup_hide_timer();
+        wf::get_core().connect(&pointer_motion);
+        wf::get_core().connect(&workspace_changed);
     }
 
-    hide();
-  }
+    void reevaluate()
+    {
+        auto view = wf::get_core().get_cursor_focus_view();
 
-  wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>>
-      pointer_motion =
-          [=](wf::input_event_signal<wlr_pointer_motion_event> *ev) {
-            auto view = wf::get_core().get_cursor_focus_view();
-
-            if (view && disabled_for.matches(view)) {
-              unhide();
-              hide_timer.disconnect();
-              return;
+        if (view && disabled_for.matches(view))
+        {
+            if (hidden)
+            {
+                wf::get_core().unhide_cursor();
+                hidden = false;
             }
 
-            unhide();
-            setup_hide_timer();
-          };
+            hide_timer.disconnect();
+            return;
+        }
 
-  wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
-      [=](wf::workspace_changed_signal *ev) { reevaluate(); };
-
-  ~wayfire_hide_cursor() {
-    pointer_motion.disconnect();
-    workspace_changed.disconnect();
-    hide_timer.disconnect();
-    unhide();
-  }
-};
-
-class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t {
-  wf::shared_data::ref_ptr_t<wayfire_hide_cursor> global_idle;
-
-  wf::activator_callback toggle_cb = [=](auto) {
-    hidden = !hidden;
-
-    if (hidden) {
-      wf::get_core().hide_cursor();
-    } else {
-      wf::get_core().unhide_cursor();
+        if (!hidden)
+        {
+            wf::get_core().hide_cursor();
+            hidden = true;
+        }
     }
 
-    return true;
-  };
+    wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
+        [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
+    {
+        auto view = wf::get_core().get_cursor_focus_view();
 
-public:
-  void init() override {
-    output->add_activator(
-        wf::option_wrapper_t<wf::activatorbinding_t>{"hide-cursor/toggle"},
-        &toggle_cb);
-  }
+        if (view && disabled_for.matches(view))
+        {
+            if (hidden)
+            {
+                wf::get_core().unhide_cursor();
+                hidden = false;
+            }
 
-  void fini() override { output->rem_binding(&toggle_cb); }
+            hide_timer.disconnect();
+            return;
+        }
+
+        if (hidden)
+        {
+            wf::get_core().unhide_cursor();
+            hidden = false;
+        }
+
+        setup_hide_timer();
+    };
+
+    wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
+        [=] (wf::workspace_changed_signal *ev)
+    {
+        reevaluate();
+    };
+
+    void setup_hide_timer()
+    {
+        hide_timer.disconnect();
+        hide_timer.set_timeout(hide_delay, [=] ()
+        {
+            reevaluate();
+        });
+    }
+
+    ~wayfire_hide_cursor()
+    {
+        pointer_motion.disconnect();
+        workspace_changed.disconnect();
+        hide_timer.disconnect();
+        if (hidden)
+        {
+            wf::get_core().unhide_cursor();
+            hidden = false;
+        }
+    }
+};
+
+class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t
+{
+    wf::shared_data::ref_ptr_t<wayfire_hide_cursor> global_idle;
+
+    wf::activator_callback toggle_cb = [=] (auto)
+    {
+        hidden = !hidden;
+
+        if (hidden)
+        {
+            wf::get_core().hide_cursor();
+        } else
+        {
+            wf::get_core().unhide_cursor();
+        }
+
+        return true;
+    };
+
+  public:
+    void init() override
+    {
+        output->add_activator(
+            wf::option_wrapper_t<wf::activatorbinding_t>{"hide-cursor/toggle"},
+            &toggle_cb);
+    }
+
+    void fini() override
+    {
+        output->rem_binding(&toggle_cb);
+    }
 };
 
 DECLARE_WAYFIRE_PLUGIN(wf::per_output_plugin_t<wayfire_hide_cursor_plugin>);
-
-} // namespace wf_hide_cursor
+}

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -34,29 +34,6 @@ namespace wf_hide_cursor
 
 bool hidden;
 
-void hide_cursor()
-{
-    wf::get_core().hide_cursor();
-    hidden = true;
-}
-
-void show_cursor()
-{
-    wf::get_core().unhide_cursor();
-    hidden = false;
-}
-
-void toggle_cursor()
-{
-    if (hidden)
-    {
-        show_cursor();
-    } else
-    {
-        hide_cursor();
-    }
-}
-
 class wayfire_hide_cursor
 {
     wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
@@ -86,6 +63,30 @@ class wayfire_hide_cursor
     }
 
   public:
+    void hide_cursor()
+    {
+        wf::get_core().hide_cursor();
+        hidden = true;
+    }
+
+    void show_cursor()
+    {
+        hide_timer.disconnect();
+        wf::get_core().unhide_cursor();
+        hidden = false;
+    }
+
+    void toggle_cursor()
+    {
+        if (hidden)
+        {
+            show_cursor();
+        } else
+        {
+            hide_cursor();
+        }
+    }
+
     wayfire_hide_cursor()
     {
         hidden = false;
@@ -98,9 +99,9 @@ class wayfire_hide_cursor
         [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
     {
         if (hidden)
-	  {
+        {
             show_cursor();
-	  }
+        }
 
         restart_hide_timer();
     };
@@ -120,7 +121,7 @@ class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t
 
     wf::activator_callback toggle_cb = [=] (auto)
     {
-        toggle_cursor();
+        global_idle->toggle_cursor();
         return true;
     };
 

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -65,6 +65,7 @@ class wayfire_hide_cursor
   public:
     void hide_cursor()
     {
+        hide_timer.disconnect();
         wf::get_core().hide_cursor();
         hidden = true;
     }

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -66,21 +66,21 @@ class wayfire_hide_cursor
     void hide_cursor()
     {
         hide_timer.disconnect();
-    
+
         if (hidden)
             return;
-    
+
         wf::get_core().hide_cursor();
         hidden = true;
     }
-    
+
     void show_cursor()
     {
         hide_timer.disconnect();
-    
+
         if (!hidden)
             return;
-    
+
         wf::get_core().unhide_cursor();
         hidden = false;
     }
@@ -102,6 +102,7 @@ class wayfire_hide_cursor
         restart_hide_timer();
 
         wf::get_core().connect(&pointer_motion);
+        wf::get_core().connect(&workspace_changed);
     }
 
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
@@ -115,9 +116,21 @@ class wayfire_hide_cursor
         restart_hide_timer();
     };
 
+    wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
+        [=] (wf::workspace_changed_signal *ev)
+    {
+        if (hidden)
+        {
+            show_cursor();
+        }
+
+        restart_hide_timer();
+    };
+
     ~wayfire_hide_cursor()
     {
         pointer_motion.disconnect();
+        workspace_changed.disconnect();
         hide_timer.disconnect();
 
         show_cursor();

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -103,7 +103,6 @@ class wayfire_hide_cursor
         restart_hide_timer();
 
         wf::get_core().connect(&pointer_motion);
-        // wf::get_core().connect(&workspace_changed);
     }
 
     void on_event()
@@ -125,7 +124,6 @@ class wayfire_hide_cursor
     ~wayfire_hide_cursor()
     {
         pointer_motion.disconnect();
-        // workspace_changed.disconnect();
         hide_timer.disconnect();
 
         show_cursor();

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -97,9 +97,11 @@ class wayfire_hide_cursor
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
         [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
     {
-        if (hidden) {
+        if (hidden)
+	  {
             show_cursor();
 	  }
+
         restart_hide_timer();
     };
 

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -28,6 +28,7 @@
 #include <wayfire/output.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/util.hpp>
+#include <fstream>
 
 namespace wf_hide_cursor
 {
@@ -102,35 +103,29 @@ class wayfire_hide_cursor
         restart_hide_timer();
 
         wf::get_core().connect(&pointer_motion);
-        wf::get_core().connect(&workspace_changed);
+        // wf::get_core().connect(&workspace_changed);
+    }
+
+    void on_event()
+    {
+        if (hidden)
+        {
+            show_cursor();
+        }
+
+        restart_hide_timer();
     }
 
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
         [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
     {
-        if (hidden)
-        {
-            show_cursor();
-        }
-
-        restart_hide_timer();
-    };
-
-    wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
-        [=] (wf::workspace_changed_signal *ev)
-    {
-        if (hidden)
-        {
-            show_cursor();
-        }
-
-        restart_hide_timer();
+        on_event();
     };
 
     ~wayfire_hide_cursor()
     {
         pointer_motion.disconnect();
-        workspace_changed.disconnect();
+        // workspace_changed.disconnect();
         hide_timer.disconnect();
 
         show_cursor();
@@ -147,17 +142,26 @@ class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t
         return true;
     };
 
+    wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
+        [=] (wf::workspace_changed_signal *ev)
+    {
+        global_idle->on_event();
+    };
+
   public:
     void init() override
     {
         output->add_activator(
             wf::option_wrapper_t<wf::activatorbinding_t>{"hide-cursor/toggle"},
             &toggle_cb);
+
+        output->connect(&workspace_changed);
     }
 
     void fini() override
     {
         output->rem_binding(&toggle_cb);
+        workspace_changed.disconnect();
     }
 };
 

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -36,8 +36,7 @@ bool hidden;
 class wayfire_hide_cursor
 {
     wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
-    wf::option_wrapper_t<std::string> disabled_for{"hide-cursor/disabled_for"};
-    wf::view_matcher_t matcher{"hide-cursor/disabled_for"};
+    wf::view_matcher_t disabled_for{"hide-cursor/disabled_for"};
     wf::wl_timer<false> hide_timer;
 
     void debounce_reevaluate()
@@ -62,7 +61,7 @@ class wayfire_hide_cursor
     {
         auto view = wf::get_core().get_cursor_focus_view();
 
-        if (disabled_for.get_value() != "none" && view && matcher.matches(view))
+        if (view && disabled_for.matches(view))
         {
             hide_timer.disconnect();
 
@@ -101,6 +100,7 @@ class wayfire_hide_cursor
         pointer_motion.disconnect();
         workspace_changed.disconnect();
         hide_timer.disconnect();
+
         if (hidden)
         {
             wf::get_core().unhide_cursor();

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -34,6 +34,29 @@ namespace wf_hide_cursor
 
 bool hidden;
 
+void hide_cursor()
+{
+    wf::get_core().hide_cursor();
+    hidden = true;
+}
+
+void show_cursor()
+{
+    wf::get_core().unhide_cursor();
+    hidden = false;
+}
+
+void toggle_cursor()
+{
+    if (hidden)
+    {
+        show_cursor();
+    } else
+    {
+        hide_cursor();
+    }
+}
+
 class wayfire_hide_cursor
 {
     wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
@@ -55,12 +78,10 @@ class wayfire_hide_cursor
 
         if (view && disabled_for.matches(view))
         {
-            wf::get_core().unhide_cursor();
-            hidden = false;
+            show_cursor();
         } else
         {
-            wf::get_core().hide_cursor();
-            hidden = true;
+            hide_cursor();
         }
     }
 
@@ -76,8 +97,7 @@ class wayfire_hide_cursor
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
         [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
     {
-        wf::get_core().unhide_cursor();
-        hidden = false;
+        show_cursor();
         restart_hide_timer();
     };
 
@@ -86,8 +106,7 @@ class wayfire_hide_cursor
         pointer_motion.disconnect();
         hide_timer.disconnect();
 
-        wf::get_core().unhide_cursor();
-        hidden = false;
+        show_cursor();
     }
 };
 
@@ -97,16 +116,7 @@ class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t
 
     wf::activator_callback toggle_cb = [=] (auto)
     {
-        hidden = !hidden;
-
-        if (hidden)
-        {
-            wf::get_core().hide_cursor();
-        } else
-        {
-            wf::get_core().unhide_cursor();
-        }
-
+        toggle_cursor();
         return true;
     };
 

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -66,13 +66,21 @@ class wayfire_hide_cursor
     void hide_cursor()
     {
         hide_timer.disconnect();
+    
+        if (hidden)
+            return;
+    
         wf::get_core().hide_cursor();
         hidden = true;
     }
-
+    
     void show_cursor()
     {
         hide_timer.disconnect();
+    
+        if (!hidden)
+            return;
+    
         wf::get_core().unhide_cursor();
         hidden = false;
     }

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -31,6 +31,7 @@
 
 namespace wf_hide_cursor
 {
+
 bool hidden;
 
 class wayfire_hide_cursor
@@ -44,19 +45,23 @@ class wayfire_hide_cursor
         hide_timer.disconnect();
         hide_timer.set_timeout(hide_delay, [=] ()
         {
-            auto view = wf::get_core().get_cursor_focus_view();
-
-            if (view && disabled_for.matches(view))
-            {
-                return;
-            }
-
-            if (!hidden)
-            {
-                wf::get_core().hide_cursor();
-                hidden = true;
-            }
+            hide_or_show_cursor();
         });
+    }
+
+    void hide_or_show_cursor()
+    {
+        auto view = wf::get_core().get_cursor_focus_view();
+
+        if (view && disabled_for.matches(view))
+        {
+            wf::get_core().unhide_cursor();
+            hidden = false;
+        } else
+        {
+            wf::get_core().hide_cursor();
+            hidden = true;
+        }
     }
 
   public:
@@ -66,63 +71,23 @@ class wayfire_hide_cursor
         restart_hide_timer();
 
         wf::get_core().connect(&pointer_motion);
-        wf::get_core().connect(&workspace_changed);
-    }
-
-    void reevaluate()
-    {
-        auto view = wf::get_core().get_cursor_focus_view();
-
-        if (view && disabled_for.matches(view))
-        {
-            hide_timer.disconnect();
-
-            if (hidden)
-            {
-                wf::get_core().unhide_cursor();
-                hidden = false;
-            }
-
-            return;
-        }
-
-        if (hidden)
-        {
-            wf::get_core().unhide_cursor();
-            hidden = false;
-        }
-
-        restart_hide_timer();
     }
 
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
         [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
     {
-        if (hidden)
-        {
-            wf::get_core().unhide_cursor();
-            hidden = false;
-        }
-    
+        wf::get_core().unhide_cursor();
+        hidden = false;
         restart_hide_timer();
-    };
-
-    wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
-        [=] (wf::workspace_changed_signal *ev)
-    {
-        reevaluate();
     };
 
     ~wayfire_hide_cursor()
     {
         pointer_motion.disconnect();
-        workspace_changed.disconnect();
         hide_timer.disconnect();
 
-        if (hidden)
-        {
-            wf::get_core().unhide_cursor();
-        }
+        wf::get_core().unhide_cursor();
+        hidden = false;
     }
 };
 
@@ -160,4 +125,5 @@ class wayfire_hide_cursor_plugin : public wf::per_output_plugin_instance_t
 };
 
 DECLARE_WAYFIRE_PLUGIN(wf::per_output_plugin_t<wayfire_hide_cursor_plugin>);
+
 }

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -39,12 +39,23 @@ class wayfire_hide_cursor
     wf::view_matcher_t disabled_for{"hide-cursor/disabled_for"};
     wf::wl_timer<false> hide_timer;
 
-    void debounce_reevaluate()
+    void restart_hide_timer()
     {
         hide_timer.disconnect();
         hide_timer.set_timeout(hide_delay, [=] ()
         {
-            reevaluate();
+            auto view = wf::get_core().get_cursor_focus_view();
+
+            if (view && disabled_for.matches(view))
+            {
+                return;
+            }
+
+            if (!hidden)
+            {
+                wf::get_core().hide_cursor();
+                hidden = true;
+            }
         });
     }
 
@@ -52,7 +63,8 @@ class wayfire_hide_cursor
     wayfire_hide_cursor()
     {
         hidden = false;
-        debounce_reevaluate();
+        restart_hide_timer();
+
         wf::get_core().connect(&pointer_motion);
         wf::get_core().connect(&workspace_changed);
     }
@@ -80,13 +92,19 @@ class wayfire_hide_cursor
             hidden = false;
         }
 
-        debounce_reevaluate();
+        restart_hide_timer();
     }
 
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
         [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
     {
-        reevaluate();
+        if (hidden)
+        {
+            wf::get_core().unhide_cursor();
+            hidden = false;
+        }
+    
+        restart_hide_timer();
     };
 
     wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -97,7 +97,9 @@ class wayfire_hide_cursor
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
         [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
     {
-        show_cursor();
+        if (hidden) {
+            show_cursor();
+	  }
         restart_hide_timer();
     };
 

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -39,11 +39,20 @@ class wayfire_hide_cursor
     wf::view_matcher_t disabled_for{"hide-cursor/disabled_for"};
     wf::wl_timer<false> hide_timer;
 
+    void debounce_reevaluate()
+    {
+        hide_timer.disconnect();
+        hide_timer.set_timeout(hide_delay, [=] ()
+        {
+            reevaluate();
+        });
+    }
+
   public:
     wayfire_hide_cursor()
     {
         hidden = false;
-        setup_hide_timer();
+        debounce_reevaluate();
         wf::get_core().connect(&pointer_motion);
         wf::get_core().connect(&workspace_changed);
     }
@@ -54,37 +63,14 @@ class wayfire_hide_cursor
 
         if (view && disabled_for.matches(view))
         {
+            hide_timer.disconnect();
+
             if (hidden)
             {
                 wf::get_core().unhide_cursor();
                 hidden = false;
             }
 
-            hide_timer.disconnect();
-            return;
-        }
-
-        if (!hidden)
-        {
-            wf::get_core().hide_cursor();
-            hidden = true;
-        }
-    }
-
-    wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
-        [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
-    {
-        auto view = wf::get_core().get_cursor_focus_view();
-
-        if (view && disabled_for.matches(view))
-        {
-            if (hidden)
-            {
-                wf::get_core().unhide_cursor();
-                hidden = false;
-            }
-
-            hide_timer.disconnect();
             return;
         }
 
@@ -94,7 +80,13 @@ class wayfire_hide_cursor
             hidden = false;
         }
 
-        setup_hide_timer();
+        debounce_reevaluate();
+    }
+
+    wf::signal::connection_t<wf::input_event_signal<wlr_pointer_motion_event>> pointer_motion =
+        [=] (wf::input_event_signal<wlr_pointer_motion_event> *ev)
+    {
+        reevaluate();
     };
 
     wf::signal::connection_t<wf::workspace_changed_signal> workspace_changed =
@@ -102,15 +94,6 @@ class wayfire_hide_cursor
     {
         reevaluate();
     };
-
-    void setup_hide_timer()
-    {
-        hide_timer.disconnect();
-        hide_timer.set_timeout(hide_delay, [=] ()
-        {
-            reevaluate();
-        });
-    }
 
     ~wayfire_hide_cursor()
     {
@@ -120,7 +103,6 @@ class wayfire_hide_cursor
         if (hidden)
         {
             wf::get_core().unhide_cursor();
-            hidden = false;
         }
     }
 };

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -36,7 +36,8 @@ bool hidden;
 class wayfire_hide_cursor
 {
     wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
-    wf::view_matcher_t disabled_for{"hide-cursor/disabled_for"};
+    wf::option_wrapper_t<std::string> disabled_for{"hide-cursor/disabled_for"};
+    wf::view_matcher_t matcher{"hide-cursor/disabled_for"};
     wf::wl_timer<false> hide_timer;
 
     void debounce_reevaluate()
@@ -61,7 +62,7 @@ class wayfire_hide_cursor
     {
         auto view = wf::get_core().get_cursor_focus_view();
 
-        if (view && disabled_for.matches(view))
+        if (disabled_for.get_value() != "none" && view && matcher.matches(view))
         {
             hide_timer.disconnect();
 


### PR DESCRIPTION
Changes in this PR:
- An option to prevent the cursor hiding in certain contexts.
- Added reevaluation on workspace switch.
- small refactoring.

**Note**: It's worth mentioning I don't have a good knowledge of C++ and I used ChatGPT as an assistant. Though the changes seems solid.